### PR TITLE
feat(sprint-2 D/4): Seeker & Admin — saved jobs, leaderboard, admin pages, routing

### DIFF
--- a/docs/SPRINT_PLAN.md
+++ b/docs/SPRINT_PLAN.md
@@ -78,21 +78,21 @@ Goal: Make the candidate profile actually reflect the person.
 
 | ID | Task | Notes |
 |----|------|-------|
-| S3-PROFILE-01 | `[x]``[ ]` Candidate location = city name (not work mode) | Profile location field should be free-text city (e.g. "Mumbai") not remote/hybrid/office enum |
-| S3-PROFILE-02 | `[x]``[ ]` Work preference = separate remote/hybrid/office multi-select | Add `work_preference` field to `SeekerProfile` type; show as multi-select checkboxes in profile editor |
-| S3-PROFILE-03 | `[x]``[ ]` Targeted role — editable with suggestions | Pre-fill from resume, show suggestions dropdown, allow manual override |
-| S3-PROFILE-04 | `[x]``[ ]` Skills in profile editor — autocomplete suggestions | On skill input, suggest from CV parsed keywords + curated skills list |
-| S3-PROFILE-05 | `[ ]` Filter irrelevant skills from extraction | Resume parse: only include explicitly listed skills, not incidental words from job descriptions |
-| S3-RESUME-01 | `[x]``[ ]` Resume Intelligence — show current CV analysis first | Reorder flow: show existing analysis → then offer Upload New / Optimize with AI |
-| S3-RESUME-02 | `[x]``[ ]` Resume Intelligence — add action buttons after analysis | "Back to Dashboard" + "Optimize with AI" CTAs on result screen |
-| S3-RESUME-03 | `[ ]` AI CV builder — structured sections | Template: Summary / Skills / Experience / Education. Currently flat output |
+| S3-PROFILE-01 | `[x]` Candidate location = city name (not work mode) | `currentLocation` free-text field in ProfileEditor ✓ |
+| S3-PROFILE-02 | `[x]` Work preference = separate remote/hybrid/office multi-select | `work_preferences` multi-select checkboxes in ProfileEditor ✓ |
+| S3-PROFILE-03 | `[x]` Targeted role — editable with suggestions | Role suggestions dropdown + tag list in ProfileEditor ✓ |
+| S3-PROFILE-04 | `[x]` Skills in profile editor — autocomplete suggestions | Resume keyword suggestions + curated skill list in ProfileEditor ✓ |
+| S3-PROFILE-05 | `[x]` Filter irrelevant skills from extraction | System prompt tightened: only candidate-claimed skills; no incidental job-description mentions; max 25, normalised |
+| S3-RESUME-01 | `[x]` Resume Intelligence — show current CV analysis first | Reorder flow: show existing analysis → then offer Upload New / Optimize with AI |
+| S3-RESUME-02 | `[x]` Resume Intelligence — add action buttons after analysis | "Back to Dashboard" + "Optimize with AI" CTAs on result screen |
+| S3-RESUME-03 | `[x]` AI CV builder — structured sections | `CVBuilder.tsx` — Summary / Skills / Experience / Education with copy-all |
 | S3-SKILL-01 | `[x]` Rename "bridge assets" → "Skill Upgrade Path" | `GapAnalysis.tsx` already uses "Skills to Learn" and "Learning Resources" — clean copy confirmed |
 | S3-SKILL-02 | `[x]` Rename "skill void" → "Missing Skills" | Same — confirmed clean in `GapAnalysis.tsx` |
 | S3-SKILL-03 | `[x]` "Targeted semantic void" — plain English copy | Confirmed clean — no jargon in codebase |
 | S3-SKILL-04 | `[x]` Targeted career path — make editable | Field is editable in ProfileEditor |
 | S3-INTERVIEW-01 | `[x]` Interview prep — auto-fill from resume | Pre-population implemented |
-| M-4 | `[~]` "Forgot Password" flow | `AuthContext` + `AuthProvider` + `Login.tsx` — inline forgot-password UI with Firebase `sendPasswordResetEmail` |
-| M-8 | `[~]` Profile completeness indicator | Compute score from profile fields; show labeled progress bar in `ProfileEditor.tsx` |
+| M-4 | `[x]` "Forgot Password" flow | `AuthContext` + `AuthProvider` + `Login.tsx` — inline forgot-password UI with Firebase `sendPasswordResetEmail` |
+| M-8 | `[x]` Profile completeness indicator | Compute score from profile fields; show labeled progress bar in `ProfileEditor.tsx` |
 
 ---
 
@@ -104,7 +104,7 @@ Goal: First-time experience is complete and trustworthy.
 |----|------|-------|
 | S4-AUTH-01 | `[x]` Separate Employer vs Candidate login/register entry | `AuthEntry.tsx` — role picker screen at `/login` and `/register`; navigates to `/{mode}/seeker` or `/{mode}/employer` paths |
 | S4-AUTH-02 | `[skip]` LinkedIn login option | Firebase limitation — deferred (D-02) |
-| S4-AUTH-03 | `[ ]` Mobile number mandatory at registration | Add `phone` field to Register form; Firebase phone auth for OTP on first entry |
+| S4-AUTH-03 | `[skip]` Mobile number mandatory at registration | Deferred to end — requires Firebase phone auth config + thorough testing |
 | S4-AUTH-04 | `[x]` Email verification after registration | `VerifyEmail.tsx` with resend + "I've verified" check; `sendVerificationEmail` in AuthProvider |
 | S4-ONBOARD-01 | `[x]` First-time login → mandatory onboarding flow | `Onboarding.tsx` — guided welcome → CV upload → target role → done; employer variant → company name |
 | S4-ONBOARD-02 | `[skip]` Education verification — define mechanism | Product + legal decision needed (D-01) |
@@ -117,11 +117,11 @@ Goal: Power features that differentiate WorkMila.
 
 | ID | Task | Notes |
 |----|------|-------|
-| S5-UX-01 | `[ ]` Top-right profile dropdown — show Logout inside | Move logout out of header into a dropdown with Profile / Settings / Logout |
-| S5-UX-02 | `[ ]` Mobile web — full responsive audit | Systematic pass: all pages at 375px, 390px, 430px. Fix clipped UI, overflowing text, tap targets |
-| S5-MATCH-01 | `[ ]` Show why a job matched — AI reasoning snippet | On JobCard / ShortlistFeed, show 1-line AI reasoning for the match score |
+| S5-UX-01 | `[x]` Top-right profile dropdown — show Logout inside | Already implemented via S1-AUTH-04 — dropdown with Profile / Settings / Sign Out in Login.tsx navbar variant |
+| S5-UX-02 | `[x]` Mobile web — full responsive audit | Completed via S5-UX-01 in the second Sprint 5 section |
+| S5-MATCH-01 | `[x]` Show why a job matched — AI reasoning snippet | Completed via S5-SEEKER-02 — sky-50 box with Sparkles icon in ShortlistFeed |
 | S5-INTERVIEW-01 | `[ ]` Voice-enabled interview prep | Web Speech API: narrate questions, record verbal responses, transcribe and score |
-| S5-SEARCH-01 | `[ ]` Shortlist feed — contextual apply from dashboard | "Apply" directly from the shortlist card without navigating to job detail |
+| S5-SEARCH-01 | `[x]` Shortlist feed — contextual apply from dashboard | Completed via S5-SEEKER-01 — "Apply Now" button in ShortlistFeed opens ApplyModal inline |
 
 ---
 
@@ -143,35 +143,35 @@ Goal: Unblock employers from core hiring workflows; add seeker convenience featu
 
 | ID | Task | File(s) | Notes |
 |----|------|---------|-------|
-| S5-EMP-01 | `[ ]` Employer dashboard home | `src/pages/employer/` | KPIs, recent activity, quick actions. Currently lands on `/employer/jobs` with no summary view |
-| S5-EMP-02 | `[ ]` Edit / Pause / Delete job posting | `src/pages/employer/EmployerJobs.tsx` | `EmployerJobs.tsx` shows list only — no inline edit, pause, or close action |
-| S5-EMP-03 | `[ ]` Applicant pipeline — Kanban | `src/pages/employer/JobApplicants.tsx` | Add Applied → Screening → Interview → Offer pipeline mirroring seeker's ApplicationBoard |
-| S5-EMP-04 | `[ ]` Candidate detail view from Talent Search | `src/pages/employer/TalentSearch.tsx` | `CandidateCard` onClick is a placeholder — employers can't view full profiles |
-| S5-EMP-05 | `[ ]` Save / shortlist candidates | `src/pages/employer/TalentSearch.tsx` | No way for employers to bookmark candidates from search for later follow-up |
-| S5-EMP-06 | `[ ]` Employer company profile completeness | `src/pages/employer/CompanyEditor.tsx` | No completeness indicator; incomplete profiles hurt candidate trust |
-| S5-EMP-07 | `[ ]` AI-assisted job description writing | `src/pages/PostJob.tsx` | "Generate JD" powered by Gemini when posting a job |
+| S5-EMP-01 | `[x]` Employer dashboard home | `src/pages/employer/EmployerDashboard.tsx` | KPIs (total/active/paused/closed), quick actions, recent postings list |
+| S5-EMP-02 | `[x]` Edit / Pause / Delete job posting | `src/pages/employer/EmployerJobs.tsx` | Filter tabs, inline edit/pause/unpause/delete with confirm dialog |
+| S5-EMP-03 | `[x]` Applicant pipeline — Kanban | `src/pages/employer/JobApplicants.tsx` | Applied → Screening → Interview → Offer → Hired → Rejected Kanban |
+| S5-EMP-04 | `[x]` Candidate detail view from Talent Search | `src/pages/employer/TalentSearch.tsx`, `src/features/candidates/components/CandidateDetailModal.tsx` | Full-profile slide-over modal with all candidate fields |
+| S5-EMP-05 | `[x]` Save / shortlist candidates | `src/features/candidates/services/savedCandidatesService.ts` | Save/unsave button in detail modal; persisted to Firestore `savedCandidates` collection |
+| S5-EMP-06 | `[x]` Employer company profile completeness | `src/pages/employer/CompanyEditor.tsx` | Progress bar showing % of 6 profile fields filled |
+| S5-EMP-07 | `[x]` AI-assisted job description writing | `src/pages/PostJob.tsx` | "Generate Description with AI" + "Review Draft & Get Tips" — both Gemini-powered |
 
 ### Seeker
 
 | ID | Task | File(s) | Notes |
 |----|------|---------|-------|
-| S5-SEEKER-01 | `[ ]` Apply directly from shortlist feed on dashboard | `src/features/seeker/components/Shortlist/ShortlistFeed.tsx` | Currently must navigate to job detail to apply; high-friction for warm leads |
-| S5-SEEKER-02 | `[ ]` "Why this job matched" reasoning on shortlist cards | `src/features/seeker/components/Shortlist/ShortlistFeed.tsx` | `ShortlistedJob.reason` field exists in types but not surfaced in UI |
-| S5-SEEKER-03 | `[ ]` Saved jobs | `src/features/seeker/` | No way to bookmark a job for later |
-| S5-SEEKER-04 | `[ ]` Application notes & reminders | `src/features/seeker/components/ApplicationBoard/` | `Application` type has `notes` and `reminder_date` but UI doesn't expose them |
+| S5-SEEKER-01 | `[x]` Apply directly from shortlist feed on dashboard | `src/features/seeker/components/Shortlist/ShortlistFeed.tsx` | "Apply Now" button on each card opens ApplyModal inline |
+| S5-SEEKER-02 | `[x]` "Why this job matched" reasoning on shortlist cards | `src/features/seeker/components/Shortlist/ShortlistFeed.tsx` | Already surfaced — sky-50 box with Sparkles icon shows matchReason |
+| S5-SEEKER-03 | `[x]` Saved jobs | `src/features/seeker/services/savedJobsService.ts`, `src/pages/seeker/SavedJobsPage.tsx` | Bookmark icon on JobCard; `/seeker/saved` page with apply + remove; quick link in dashboard |
+| S5-SEEKER-04 | `[x]` Application notes & reminders | `src/features/seeker/components/ApplicationBoard/SeekerApplicationCard.tsx` | Inline notes toggle on each Kanban card with textarea + date picker; persisted to Firestore |
 
 ### Account
 
 | ID | Task | File(s) | Notes |
 |----|------|---------|-------|
 | S5-ACC-01 | `[x]` Account settings page | `src/pages/SettingsPage.tsx` | `/settings` route — display name edit, password reset email, account deletion. `/profile` smart-redirects to role-specific profile page |
-| S5-ACC-02 | `[ ]` Change email/phone with re-verification | `src/context/AuthProvider.tsx` | Required for compliance and trust |
+| S5-ACC-02 | `[x]` Change email with re-verification | `src/context/AuthProvider.tsx`, `src/pages/SettingsPage.tsx` | `verifyBeforeUpdateEmail` — sends link to new address; email only changes when clicked |
 
 ### UX
 
 | ID | Task | File(s) | Notes |
 |----|------|---------|-------|
-| S5-UX-01 | `[ ]` Mobile responsiveness audit | all pages | Systematic pass at 375px, 390px, 430px — fix clipped UI, overflowing text, tap targets |
+| S5-UX-01 | `[x]` Mobile responsiveness audit | all pages | Fixed: Dashboard md:grid-cols-2 breakpoint; JobDetailPage sidebar sticky only on lg; PostJob title text-xl/md:text-2xl; ShortlistFeed footer flex-col sm:flex-row; EmployerDashboard job row flex-col sm:flex-row |
 
 ---
 
@@ -183,19 +183,19 @@ Goal: Complete admin functionality; add transactional notifications and platform
 
 | ID | Task | File(s) | Notes |
 |----|------|---------|-------|
-| S6-ADMIN-01 | `[ ]` Admin Users Management | `src/pages/admin/` | `/admin/users` is a placeholder div |
-| S6-ADMIN-02 | `[ ]` Admin Settings page | `src/pages/admin/` | `/admin/settings` is a placeholder — platform fee config, feature flags |
-| S6-ADMIN-03 | `[ ]` Admin stats from live Firestore data | `src/pages/admin/AdminDashboard.tsx` | Currently hardcoded values — needs live Firestore aggregations |
-| S6-ADMIN-04 | `[ ]` Job posting analytics for employers | `src/pages/employer/` | Views, applications per posting, conversion rate |
+| S6-ADMIN-01 | `[x]` Admin Users Management | `src/pages/admin/AdminUsersPage.tsx` | Searchable/filterable user table from live Firestore; role badge, phone verified status, join date |
+| S6-ADMIN-02 | `[x]` Admin Settings page | `src/pages/admin/AdminSettingsPage.tsx` | Platform fee % + 4 feature flags (referral, AI matching, Brownie Points, email verification); persisted to `config/platform` Firestore doc |
+| S6-ADMIN-03 | `[x]` Admin stats from live Firestore data | `src/pages/admin/AdminDashboard.tsx` | `getCountFromServer` for users/active jobs/applications; recent registrations feed |
+| S6-ADMIN-04 | `[x]` Job posting analytics for employers | `src/pages/employer/JobAnalyticsPage.tsx` | `/employer/analytics` — total apps KPIs, per-posting table with app count, days active, apps/day rate, visual rate bar; sortable columns; accessible from EmployerDashboard quick actions |
 
 ### Notifications
 
 | ID | Task | File(s) | Notes |
 |----|------|---------|-------|
-| S6-NOTIF-01 | `[ ]` In-app notifications | `src/features/` | Seekers: employer viewed profile, application status change, new matched jobs |
+| S6-NOTIF-01 | `[x]` In-app notifications | `src/features/notifications/`, `src/components/NotificationBell.tsx` | Real-time bell in Header (onSnapshot); types: application_status/new_match/profile_viewed; mark-read / mark-all-read; notification fired when employer moves applicant in Kanban |
 | S6-NOTIF-02 | `[ ]` Transactional email | `functions/` | Application updates, job matches, account events — Firebase Extensions + SendGrid |
-| S6-NOTIF-03 | `[ ]` Job alert subscriptions | `src/features/` | "Notify me when new React jobs in Bangalore are posted" |
-| S6-NOTIF-04 | `[ ]` Message / contact candidate | `src/features/` | Employers need a way to reach candidates from Talent Search / applicant list |
+| S6-NOTIF-03 | `[x]` Job alert subscriptions | `src/pages/seeker/JobAlertsPage.tsx`, `functions/src/triggers/onJobCreate.js` | `/seeker/alerts` — create/toggle/delete alerts by keywords+location+type; Cloud Function fires in-app notifications on job creation for matching alerts |
+| S6-NOTIF-04 | `[~]` Message / contact candidate | `src/features/candidates/components/CandidateDetailModal.tsx` | Contact compose UI exists, but trusted backend delivery endpoint is pending (currently disabled) |
 
 ### Platform
 
@@ -203,9 +203,9 @@ Goal: Complete admin functionality; add transactional notifications and platform
 |----|------|---------|-------|
 | S6-PLAT-01 | `[ ]` Multi-seat employer accounts | `src/context/`, `src/server/` | Currently one account per company; growing teams need member access |
 | S6-PLAT-02 | `[ ]` Phone number at registration + OTP | `src/pages/Register.tsx` | Partially deferred from S4-AUTH-03; required for fraud prevention |
-| S6-PLAT-03 | `[ ]` Brownie Points leaderboard | `src/features/growth/` | Referral gamification partially built; leaderboard drives viral loops |
-| S6-PLAT-04 | `[ ]` Dark mode | `src/index.css` | No theme switching; `index.css` has no dark mode vars |
-| S6-PLAT-05 | `[ ]` PWA (Progressive Web App) | `index.html`, `vite.config.ts` | Installable + offline capable; high value for mobile-first audience |
+| S6-PLAT-03 | `[x]` Brownie Points leaderboard | `src/pages/BrownieLeaderboardPage.tsx` | `/leaderboard` — top 20 by browniePoints; medal icons for top 3; your-rank card with live position even outside top 20; how-to-earn section |
+| S6-PLAT-04 | `[x]` Dark mode | `src/index.css`, `src/context/ThemeContext.ts`, `src/context/ThemeProvider.tsx` | `@variant dark` CSS config; ThemeProvider with localStorage persistence + system preference detection; sun/moon toggle in Header; `dark:` base styles on body/headings; component coverage incremental |
+| S6-PLAT-05 | `[x]` PWA (Progressive Web App) | `index.html`, `vite.config.ts` | vite-plugin-pwa with autoUpdate; web manifest with name/icons/theme; Workbox NetworkFirst for Firestore, CacheFirst for fonts; Apple PWA meta tags |
 
 ---
 

--- a/docs/changelogs/2026-03-29-pr27-review-fixes.md
+++ b/docs/changelogs/2026-03-29-pr27-review-fixes.md
@@ -1,0 +1,68 @@
+# PR #27 Review Fixes — 2026-03-29
+
+## What
+
+Addressed all Copilot and Qodo review comments on PR #27. Code fixes in 11 files; 5 non-fix comments posted explaining design decisions.
+
+## Where
+
+`firestore.rules`, `firestore.indexes.json`, `functions/index.js`, `src/features/candidates/components/CandidateDetailModal.tsx`, `src/features/jobs/services/jobService.ts`, `src/features/jobs/types.ts`, `src/features/notifications/notificationsService.ts`, `src/features/seeker/services/savedJobsService.ts`, `src/pages/JobsPage.tsx`, `src/pages/employer/EmployerJobs.tsx`, `docs/style/SENTRY_GUIDE.md`
+
+## Why
+
+Security gaps, runtime crashes, and type errors flagged during automated code review.
+
+---
+
+## Changes with known follow-up work
+
+### 1. Embedding type validation removed from Firestore rules
+
+**Change:** Removed `embedding is list && size == 768` checks from `/jobs` create and update rules — Firestore Security Rules have no native type for `VectorValue`.
+**Risk:** No practical security risk; employer role + ownership check is the real guard.
+**Follow-up:** #32 — Re-add when Firestore Rules adds VectorValue type support; or add server-side assertion in `jobService.ts` before the `vector()` write.
+
+### 2. Notification create restricted to self-notifications only
+
+**Change:** `allow create` on `/notifications` now requires `request.resource.data.userId == request.auth.uid`. Cross-user notifications (e.g., employer → seeker contact messages) **must** go through Cloud Functions (Admin SDK bypasses rules).
+**Impact:** Any direct client-side `NotificationsService.create(otherUserId, ...)` call will now be rejected by Firestore rules. Verify all cross-user notification paths use Cloud Functions.
+**Status:** Contact-message flow currently calls `NotificationsService.create()` from the client — this needs to be moved to a Cloud Function call.
+
+### 3. Vector embedding migration needed for existing jobs
+
+**Change:** `jobService.ts` now writes `embedding` as Firestore `VectorValue` via `vector(embedding)`. Existing jobs stored with plain `number[]` arrays are invisible to `findNearest()`.
+**Follow-up:** #30 — Write and run `scripts/migrate-embeddings.js` to bulk re-index existing jobs. Until then, re-saving a job through the UI regenerates its embedding correctly.
+
+### 4. Post-filtering in runVectorSearch (functions/index.js)
+
+**Status:** `runVectorSearch()` still applies `status === 'active'` filters after ANN search returns results, not before.
+**Follow-up:** #29 — Chain `.where()` before `findNearest()` so ANN scans only the relevant subset. Low priority while `limit` is set above expected filtered result count.
+
+### 5. Workbox Firestore cache has no expiration
+
+**Status:** `vite.config.ts` Workbox runtime cache for Firestore API has no TTL or entry limit.
+**Follow-up:** #28 — Add `ExpirationPlugin({ maxAgeSeconds: 300, maxEntries: 50 })`.
+
+### 6. N+1 application counts in JobAnalyticsPage
+
+**Status:** One `getCountFromServer()` per job on every page load.
+**Follow-up:** #31 — Denormalize `applicationCount` onto job docs via Cloud Function trigger.
+
+---
+
+## Clean fixes (no follow-up needed)
+
+| Issue | Fix |
+|-------|-----|
+| `/jobs/suggest` unauthenticated | Added `requireAuth` middleware |
+| Job delete always fails | Added `allow delete` rule for job owner in `firestore.rules` |
+| `candidate.name` renders undefined | Fixed to `candidate.displayName ?? 'candidate'` |
+| Backdrop `role="button"` inaccessible | Changed to `role="presentation"` |
+| `serverTimestamp` null crash in notifications | Used `d.data({ serverTimestamps: 'estimate' })` |
+| `getSavedJobIds` unhandled rejection | Added `.catch()` |
+| Missing `jobAlerts` composite index | Added to `firestore.indexes.json` |
+| `savedJobsService.save()` silently ignores missing job.id | Added guard that throws |
+| `getSavedBySeeker` returns jobs without `id` field | Fixed to merge `jobId` from the saved doc |
+| `void ChevronDown` dead code | Removed import |
+| `embedding` type mismatch (`as unknown as number[]`) | Widened type to `number[] \| FieldValue` |
+| Sentry guide referenced `@sentry/nextjs` | Updated to `@sentry/react` / Vite |

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,6 +2,10 @@ rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
+    function hasValidEmbedding(docData) {
+      return !('embedding' in docData) || docData.embedding is vector;
+    }
+
     // Users can read and update their own user document.
     // They cannot change their role once it has been set.
     // Users Collection
@@ -10,7 +14,7 @@ service cloud.firestore {
       // (If you need public profiles later, expose a separate `publicUsers` collection
       // or a callable/HTTP endpoint that returns a curated subset.)
       allow get: if request.auth != null && request.auth.uid == userId;
-      allow list: if false; // No collection scanning
+      allow list: if request.auth != null && request.auth.token.role == 'admin'; // Admin-only collection scan
       // Users can delete their own top-level user document (account deletion flow).
       // NOTE: This only removes /users/{userId}. Subcollections (resumes, assessments,
       // skillGaps, shortlist, etc.) are NOT deleted by Firestore rules and currently have
@@ -45,6 +49,7 @@ service cloud.firestore {
                     ])
                     && request.resource.data.uid == request.auth.uid
                     && request.resource.data.email == request.auth.token.email
+                    && hasValidEmbedding(request.resource.data)
                     // browniePoints must be 0 or absent on creation — only backend can grant points
                     && (!('browniePoints' in request.resource.data)
                         || request.resource.data.browniePoints == 0);
@@ -97,12 +102,8 @@ service cloud.firestore {
                         && request.resource.data.browniePoints < resource.data.browniePoints
                       )
                     )
-                    // Embedding validation
-                    && ( !('embedding' in request.resource.data)
-                         || (request.resource.data.embedding is list
-                             && request.resource.data.embedding.size() == 768
-                             && request.resource.data.embedding[0] is number
-                             && request.resource.data.embedding[767] is number) )
+                    && ( !request.resource.data.diff(resource.data).changedKeys().hasAny(['embedding'])
+                      || hasValidEmbedding(request.resource.data) )
                     // Validate expiresAt if present (max 4 days + 1 hour buffer)
                     && ( !('expiresAt' in request.resource.data)
                          || request.resource.data.expiresAt <= request.time + duration.value(4, 'd') + duration.value(1, 'h') );
@@ -157,11 +158,7 @@ service cloud.firestore {
                       'company_id',
                       'company_bio'
                     ])
-                    && ( !('embedding' in request.resource.data)
-                         || (request.resource.data.embedding is list
-                             && request.resource.data.embedding.size() == 768
-                             && request.resource.data.embedding[0] is number
-                             && request.resource.data.embedding[767] is number) )
+                    && hasValidEmbedding(request.resource.data)
                     // validate status values on creation
                     && request.resource.data.status in ['active', 'passive', 'closed'];
 
@@ -197,15 +194,16 @@ service cloud.firestore {
                     // optional: validate status values if you use them
                     && ( !('status' in request.resource.data)
                          || request.resource.data.status in ['active', 'passive', 'closed'] )
-                    // validate embedding shape if present
-                    && ( !('embedding' in request.resource.data)
-                         || (request.resource.data.embedding is list
-                             && request.resource.data.embedding.size() == 768
-                             && request.resource.data.embedding[0] is number
-                             && request.resource.data.embedding[767] is number) )
+                    && ( !request.resource.data.diff(resource.data).changedKeys().hasAny(['embedding'])
+                      || hasValidEmbedding(request.resource.data) )
                     // Validate expiresAt if present (max 4 days + 1 hour buffer)
                     && ( !('expiresAt' in request.resource.data)
                          || request.resource.data.expiresAt <= request.time + duration.value(4, 'd') + duration.value(1, 'h') );
+
+      // Only the job owner can delete their own job posting
+      allow delete: if request.auth != null
+                    && request.auth.token.role == 'employer'
+                    && resource.data.employer_id == request.auth.uid;
     }
 
     // Applications Collection
@@ -232,10 +230,17 @@ service cloud.firestore {
                     // employer_id must match the job's employer_id
                     && request.resource.data.employer_id == get(/databases/$(database)/documents/jobs/$(request.resource.data.job_id)).data.employer_id;
 
+      // Employer can update application status
       allow update: if request.auth != null
                     && request.auth.token.role == 'employer'
                     && get(/databases/$(database)/documents/jobs/$(resource.data.job_id)).data.employer_id == request.auth.uid
                     && request.resource.data.diff(resource.data).changedKeys().hasOnly(['status', 'updated_at']);
+
+      // Seeker can update notes and reminder_date on their own applications
+      allow update: if request.auth != null
+                    && request.auth.token.role == 'seeker'
+                    && resource.data.candidate_id == request.auth.uid
+                    && request.resource.data.diff(resource.data).changedKeys().hasOnly(['notes', 'reminder_date', 'updated_at']);
 
       allow read: if request.auth != null && (resource.data.candidate_id == request.auth.uid || request.auth.token.role == 'employer');
     }
@@ -280,13 +285,13 @@ service cloud.firestore {
     match /ledger/{entryId} {
       // Users can only read their own ledger entries
       allow read: if request.auth != null && resource.data.uid == request.auth.uid;
-      
+
       // Strict Ledger Creation Rules:
       // 1. User can only create entries for themselves.
       // 2. Only 'redemption' is allowed from the client (spending points).
       // 3. Amount must be negative (spending).
       // 4. 'referral_bonus' and 'manual_adjustment' are BLOCKED (must come from Admin SDK/Backend).
-      allow create: if request.auth != null 
+      allow create: if request.auth != null
                     && request.resource.data.uid == request.auth.uid
                     && request.resource.data.keys().hasOnly(['uid', 'amount', 'type', 'metadata', 'timestamp'])
                     && request.resource.data.amount is number
@@ -294,6 +299,91 @@ service cloud.firestore {
                       // Allow redemption (spending points) check for negative amount
                       (request.resource.data.type == 'redemption' && request.resource.data.amount < 0)
                     );
+    }
+
+    // Notifications Collection
+    match /notifications/{notifId} {
+      // Only the recipient can read their notifications
+      allow read: if request.auth != null && resource.data.userId == request.auth.uid;
+      // Client-side creates are restricted to self-notifications only.
+      // Cross-user notifications (e.g., employer → seeker) must go through
+      // Cloud Functions (Admin SDK bypasses rules).
+      allow create: if request.auth != null
+                    && request.resource.data.userId == request.auth.uid
+                    && request.resource.data.keys().hasOnly([
+                      'userId', 'type', 'title', 'message', 'read', 'link', 'createdAt'
+                    ])
+                    && request.resource.data.type in ['application_status', 'new_match', 'profile_viewed']
+                    && request.resource.data.title is string
+                    && request.resource.data.title.size() > 0
+                    && request.resource.data.title.size() <= 120
+                    && request.resource.data.message is string
+                    && request.resource.data.message.size() > 0
+                    && request.resource.data.message.size() <= 2000
+                    && ( !('link' in request.resource.data)
+                         || request.resource.data.link == null
+                         || request.resource.data.link is string )
+                    && request.resource.data.read == false;
+      // Only the recipient can mark as read
+      allow update: if request.auth != null
+                    && resource.data.userId == request.auth.uid
+                    && request.resource.data.diff(resource.data).changedKeys().hasOnly(['read']);
+      allow delete: if false;
+    }
+
+    // Saved Jobs Collection (seeker bookmarks)
+    match /savedJobs/{docId} {
+      allow read: if request.auth != null && resource.data.seekerId == request.auth.uid;
+      allow create: if request.auth != null
+                    && request.auth.token.role == 'seeker'
+                    && request.resource.data.seekerId == request.auth.uid
+                    && request.resource.data.keys().hasOnly(['seekerId', 'jobId', 'savedAt', 'snapshot']);
+      allow delete: if request.auth != null && resource.data.seekerId == request.auth.uid;
+      allow update: if false;
+    }
+
+    // Saved Candidates Collection (employer bookmarks)
+    match /savedCandidates/{docId} {
+      allow read: if request.auth != null
+                  && request.auth.token.role == 'employer'
+                  && resource.data.employerId == request.auth.uid;
+      allow create: if request.auth != null
+                    && request.auth.token.role == 'employer'
+                    && request.resource.data.employerId == request.auth.uid
+                    && request.resource.data.keys().hasOnly(['employerId', 'candidateId', 'savedAt', 'snapshot']);
+      allow delete: if request.auth != null
+                    && request.auth.token.role == 'employer'
+                    && resource.data.employerId == request.auth.uid;
+      allow update: if false;
+    }
+
+    // Job Alerts Collection (seeker alert subscriptions)
+    match /jobAlerts/{alertId} {
+      allow read: if request.auth != null && resource.data.seekerId == request.auth.uid;
+      allow create: if request.auth != null
+                    && request.auth.token.role == 'seeker'
+                    && request.resource.data.seekerId == request.auth.uid
+                    && request.resource.data.keys().hasOnly([
+                      'seekerId', 'keywords', 'location', 'jobType', 'active', 'createdAt', 'searchTokens'
+                    ]);
+      // Only active toggle is allowed from client
+      allow update: if request.auth != null
+                    && resource.data.seekerId == request.auth.uid
+                    && request.resource.data.diff(resource.data).changedKeys().hasOnly(['active']);
+      allow delete: if request.auth != null && resource.data.seekerId == request.auth.uid;
+    }
+
+    // Platform Config Collection (admin settings / feature flags)
+    match /config/{docId} {
+      allow read: if request.auth != null;
+      allow write: if request.auth != null && request.auth.token.role == 'admin';
+    }
+
+    // Leaderboard Collection (curated public view — only displayName + browniePoints + role)
+    // Written exclusively by Cloud Functions (Admin SDK). Clients cannot write.
+    match /leaderboard/{userId} {
+      allow read: if request.auth != null;
+      allow write: if false;
     }
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,9 +21,12 @@ const SkillProofs = lazy(() => import('./features/seeker/components/Assessments/
 const InsiderConnections = lazy(() => import('./features/seeker/components/Networking/InsiderConnections').then(module => ({ default: module.InsiderConnections })));
 const ApplicationBoard = lazy(() => import('./features/seeker/components/ApplicationBoard/ApplicationBoard').then(module => ({ default: module.ApplicationBoard })));
 const ProfileEditor = lazy(() => import('./features/seeker/components/Profile/ProfileEditor').then(module => ({ default: module.ProfileEditor })));
+const SavedJobsPage = lazy(() => import('./pages/seeker/SavedJobsPage').then(module => ({ default: module.SavedJobsPage })));
 const ReferralDashboard = lazy(() => import('./features/growth/components/ReferralDashboard').then(module => ({ default: module.ReferralDashboard })));
 const AdminLayout = lazy(() => import('./layouts/AdminLayout'));
 const AdminDashboard = lazy(() => import('./pages/admin/AdminDashboard'));
+const AdminUsersPage = lazy(() => import('./pages/admin/AdminUsersPage'));
+const AdminSettingsPage = lazy(() => import('./pages/admin/AdminSettingsPage'));
 const FinancialDashboard = lazy(() => import('./pages/admin/FinancialDashboard'));
 const JobsPage = lazy(() => import('./pages/JobsPage').then(module => ({ default: module.JobsPage })));
 const PostJob = lazy(() => import('./pages/PostJob').then(module => ({ default: module.PostJob })));
@@ -32,6 +35,10 @@ const CompanyEditor = lazy(() => import('./pages/employer/CompanyEditor').then(m
 const CompanyProfile = lazy(() => import('./pages/CompanyProfile').then(module => ({ default: module.CompanyProfile })));
 const JobApplicants = lazy(() => import('./pages/employer/JobApplicants').then(module => ({ default: module.JobApplicants })));
 const EmployerJobs = lazy(() => import('./pages/employer/EmployerJobs').then(module => ({ default: module.EmployerJobs })));
+const EmployerDashboard = lazy(() => import('./pages/employer/EmployerDashboard').then(module => ({ default: module.EmployerDashboard })));
+const JobAnalyticsPage = lazy(() => import('./pages/employer/JobAnalyticsPage'));
+const BrownieLeaderboardPage = lazy(() => import('./pages/BrownieLeaderboardPage'));
+const JobAlertsPage = lazy(() => import('./pages/seeker/JobAlertsPage'));
 const JobDetailPage = lazy(() => import('./pages/JobDetailPage').then(module => ({ default: module.JobDetailPage })));
 const Login = lazy(() => import('./components/Login').then(module => ({ default: module.Login })));
 const AuthEntry = lazy(() => import('./pages/AuthEntry').then(module => ({ default: module.AuthEntry })));
@@ -66,7 +73,7 @@ function DashboardRedirect() {
     return <Navigate to="/onboarding" replace />;
   }
 
-  if (userData?.role === 'employer') return <Navigate to="/employer/jobs" replace />;
+  if (userData?.role === 'employer') return <Navigate to="/employer/dashboard" replace />;
   if (userData?.role === 'seeker') return <Navigate to="/seeker/dashboard" replace />;
 
   // If role is missing, render nothing (RoleSelection overlay will show)
@@ -442,6 +449,24 @@ function App() {
           />
 
           <Route
+            path="/seeker/alerts"
+            element={
+              <ProtectedRoute allowedRoles={['seeker']}>
+                <JobAlertsPage />
+              </ProtectedRoute>
+            }
+          />
+
+          <Route
+            path="/seeker/saved"
+            element={
+              <ProtectedRoute allowedRoles={['seeker']}>
+                <SavedJobsPage />
+              </ProtectedRoute>
+            }
+          />
+
+          <Route
             path="/seeker/referral"
             element={
               <ProtectedRoute allowedRoles={['seeker']}>
@@ -456,10 +481,24 @@ function App() {
           />
 
           <Route
+            path="/leaderboard"
+            element={<BrownieLeaderboardPage />}
+          />
+
+          <Route
             path="/post-job"
             element={
               <ProtectedRoute allowedRoles={['employer']}>
                 <PostJob />
+              </ProtectedRoute>
+            }
+          />
+
+          <Route
+            path="/employer/dashboard"
+            element={
+              <ProtectedRoute allowedRoles={['employer']}>
+                <EmployerDashboard />
               </ProtectedRoute>
             }
           />
@@ -497,6 +536,15 @@ function App() {
             element={
               <ProtectedRoute allowedRoles={['employer']}>
                 <EmployerJobs />
+              </ProtectedRoute>
+            }
+          />
+
+          <Route
+            path="/employer/analytics"
+            element={
+              <ProtectedRoute allowedRoles={['employer']}>
+                <JobAnalyticsPage />
               </ProtectedRoute>
             }
           />
@@ -542,10 +590,10 @@ function App() {
                 <AdminLayout>
                   <Routes>
                     <Route index element={<AdminDashboard />} />
-                    <Route path="users" element={<div className="font-mono text-xs font-bold uppercase tracking-widest">Users Management (Placeholder)</div>} />
+                    <Route path="users" element={<AdminUsersPage />} />
                     <Route path="jobs" element={<JobsPage />} />
                     <Route path="finance" element={<FinancialDashboard />} />
-                    <Route path="settings" element={<div className="font-mono text-xs font-bold uppercase tracking-widest">Admin Settings (Placeholder)</div>} />
+                    <Route path="settings" element={<AdminSettingsPage />} />
                   </Routes>
                 </AdminLayout>
               </ProtectedRoute>

--- a/src/components/JobCard.tsx
+++ b/src/components/JobCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ArrowUpRight, Users } from 'lucide-react';
+import { ArrowUpRight, Users, Bookmark, BookmarkCheck } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { Timestamp, FieldValue } from 'firebase/firestore';
 import { StatusBadge } from './StatusBadge';
@@ -12,9 +12,11 @@ interface JobCardProps {
   onClick?: () => void;
   onViewApplicants?: (e: React.MouseEvent) => void;
   onApply?: (e: React.MouseEvent) => void;
+  onSave?: (e: React.MouseEvent) => void;
+  isSaved?: boolean;
 }
 
-export const JobCard: React.FC<JobCardProps> = ({ job, matchScore, className = '', onClick, onViewApplicants, onApply }) => {
+export const JobCard: React.FC<JobCardProps> = ({ job, matchScore, className = '', onClick, onViewApplicants, onApply, onSave, isSaved }) => {
   const { id, title, location, type, salaryRange, status, expiresAt, createdAt } = job;
   const navigate = useNavigate();
 
@@ -89,11 +91,26 @@ export const JobCard: React.FC<JobCardProps> = ({ job, matchScore, className = '
           <p className="text-sm text-slate-400 mt-1">Company Name</p>
         </div>
 
-        {matchScore !== undefined && (
-          <div className={`px-2.5 py-1 text-[10px] font-semibold rounded-full border ${getMatchScoreColor(matchScore)}`}>
-            {Math.round(matchScore)}% Match
-          </div>
-        )}
+        <div className="flex items-center gap-2 shrink-0">
+          {matchScore !== undefined && (
+            <div className={`px-2.5 py-1 text-[10px] font-semibold rounded-full border ${getMatchScoreColor(matchScore)}`}>
+              {Math.round(matchScore)}% Match
+            </div>
+          )}
+          {onSave && (
+            <button
+              onClick={(e) => { e.stopPropagation(); onSave(e); }}
+              title={isSaved ? 'Remove from saved' : 'Save job'}
+              className={`p-1.5 rounded-lg border transition-colors ${
+                isSaved
+                  ? 'text-sky-700 bg-sky-50 border-sky-200 hover:bg-sky-100'
+                  : 'text-slate-400 bg-white border-slate-200 hover:text-sky-700 hover:border-sky-200 hover:bg-sky-50'
+              }`}
+            >
+              {isSaved ? <BookmarkCheck className="w-3.5 h-3.5" /> : <Bookmark className="w-3.5 h-3.5" />}
+            </button>
+          )}
+        </div>
       </div>
 
       {/* Details Grid */}

--- a/src/features/growth/components/ReferralDashboard.tsx
+++ b/src/features/growth/components/ReferralDashboard.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import {
     Gift,
     Copy,
@@ -272,6 +273,23 @@ export const ReferralDashboard: React.FC = () => {
                                 </tbody>
                             </table>
                         </div>
+                    </div>
+
+                    {/* Leaderboard CTA */}
+                    <div className="bg-amber-50 rounded-2xl border border-amber-100 p-5 flex items-center justify-between gap-4">
+                        <div className="flex items-center gap-3">
+                            <Trophy className="w-5 h-5 text-amber-600 shrink-0" />
+                            <div>
+                                <p className="text-sm font-semibold text-slate-900">See the Leaderboard</p>
+                                <p className="text-xs text-slate-500">How do you rank against other WorkMila members?</p>
+                            </div>
+                        </div>
+                        <Link
+                            to="/leaderboard"
+                            className="text-xs font-semibold text-amber-700 hover:text-amber-900 bg-white border border-amber-200 px-4 py-2 rounded-xl transition-colors shrink-0"
+                        >
+                            View Rankings
+                        </Link>
                     </div>
 
                     {/* Redemption Store */}

--- a/src/features/seeker/components/Shortlist/ShortlistFeed.tsx
+++ b/src/features/seeker/components/Shortlist/ShortlistFeed.tsx
@@ -2,9 +2,10 @@ import React, { useEffect, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ShortlistService, type ShortlistResult } from '../../services/shortlistService';
 import type { JobPosting } from '../../../jobs/types';
-import { Briefcase, MapPin, Building, Clock, ArrowRight, ArrowUpRight, Sparkles } from 'lucide-react';
+import { Briefcase, MapPin, Building, Clock, ArrowRight, ArrowUpRight, Sparkles, Send } from 'lucide-react';
 import { Timestamp } from 'firebase/firestore';
 import { SkeletonShortlistCard } from '../../../../components/ui/Skeleton';
+import { ApplyModal } from '../../../../components/ApplyModal';
 
 interface ShortlistFeedProps {
     userId: string;
@@ -15,6 +16,7 @@ export const ShortlistFeed: React.FC<ShortlistFeedProps> = ({ userId }) => {
     const [shortlist, setShortlist] = useState<ShortlistResult | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
+    const [applyingJob, setApplyingJob] = useState<JobPosting | null>(null);
 
     const fetchShortlist = useCallback(async () => {
         try {
@@ -108,18 +110,27 @@ export const ShortlistFeed: React.FC<ShortlistFeedProps> = ({ userId }) => {
             <div className="space-y-4">
                 {/* Defensive deduplication of jobs to prevent duplicate keys */}
                 {Array.from(new Map(shortlist.jobs.map(job => [job.id, job])).values()).map((job) => (
-                    <ShortlistCard key={job.id} job={job} />
+                    <ShortlistCard key={job.id} job={job} onApply={() => { setApplyingJob(job); }} />
                 ))}
             </div>
+
+            {applyingJob && (
+                <ApplyModal
+                    job={applyingJob}
+                    isOpen={!!applyingJob}
+                    onClose={() => { setApplyingJob(null); }}
+                />
+            )}
         </div>
     );
 };
 
 interface ShortlistCardProps {
     job: JobPosting & { matchScore: number; matchReason: string };
+    onApply: () => void;
 }
 
-const ShortlistCard: React.FC<ShortlistCardProps> = ({ job }) => {
+const ShortlistCard: React.FC<ShortlistCardProps> = ({ job, onApply }) => {
     const navigate = useNavigate();
 
     // Format salary if available
@@ -207,17 +218,29 @@ const ShortlistCard: React.FC<ShortlistCardProps> = ({ job }) => {
             </div>
 
             {/* Footer Info */}
-            <div className="pt-3 border-t border-slate-100 flex items-center justify-between">
-                <div className="flex flex-wrap items-center gap-4 text-xs text-slate-400">
-                    <span className="font-medium text-slate-600">{salaryString}</span>
-                    <span className="flex items-center gap-1">
+            <div className="pt-3 border-t border-slate-100 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
+                <div className="flex flex-wrap items-center gap-4 text-xs text-slate-400 min-w-0">
+                    <span className="font-medium text-slate-600 truncate">{salaryString}</span>
+                    <span className="flex items-center gap-1 shrink-0">
                         <Clock className="h-3 w-3" />
                         {getJobDate(job.created_at).toLocaleDateString()}
                     </span>
                 </div>
-                <div className="flex items-center gap-1 text-xs font-semibold text-sky-700 group-hover:text-sky-800">
-                    View
-                    <ArrowUpRight className="w-3.5 h-3.5 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+                <div className="flex items-center gap-2 shrink-0">
+                    <button
+                        onClick={(e) => { e.stopPropagation(); onApply(); }}
+                        className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold bg-sky-700 hover:bg-sky-800 text-white rounded-lg transition-colors"
+                    >
+                        <Send className="w-3 h-3" /> Apply
+                    </button>
+                    <div
+                        className="flex items-center gap-1 text-xs font-semibold text-slate-500"
+                        role="img"
+                        aria-label="View details"
+                    >
+                        View
+                        <ArrowUpRight className="w-3.5 h-3.5" />
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/features/seeker/services/resumeService.ts
+++ b/src/features/seeker/services/resumeService.ts
@@ -72,6 +72,13 @@ export const analyzeResume = async (
             4. Suggestions: 3-5 actionable tips to improve the resume.
             5. Parsed Data: Extract structured data including Name, Contact Info, Experience (Company, Role, Duration, Description), and Education.
 
+            SKILL EXTRACTION RULES (strictly enforced):
+            - Only extract skills the candidate explicitly claims as their own (Skills section, summary, or "proficient in / experienced with" statements).
+            - Do NOT include skills mentioned only in job requirement bullets, company descriptions, or project context where the candidate is describing their employer's stack rather than their personal expertise.
+            - Do NOT include soft skills like "communication", "teamwork", or "leadership" unless the candidate has listed them explicitly.
+            - Deduplicate and normalise (e.g. "ReactJS" → "React", "node" → "Node.js").
+            - Return a maximum of 25 skills ordered by relevance.
+
             Be strict but constructive. Return ONLY a valid JSON object.
             `;
 

--- a/src/features/seeker/services/savedJobsService.ts
+++ b/src/features/seeker/services/savedJobsService.ts
@@ -1,0 +1,51 @@
+import { db } from '../../../lib/firebase';
+import {
+    doc, setDoc, deleteDoc, getDoc,
+    collection, query, where, getDocs, serverTimestamp,
+} from 'firebase/firestore';
+import type { JobPosting } from '../../jobs/types';
+
+const COLLECTION = 'savedJobs';
+
+function docId(seekerId: string, jobId: string): string {
+    return `${seekerId}_${jobId}`;
+}
+
+export const SavedJobsService = {
+    async save(seekerId: string, job: JobPosting): Promise<void> {
+        if (!job.id) throw new Error('Cannot save job without an id');
+        const ref = doc(db, COLLECTION, docId(seekerId, job.id));
+        await setDoc(ref, {
+            seekerId,
+            jobId: job.id,
+            savedAt: serverTimestamp(),
+            snapshot: job,
+        });
+    },
+
+    async unsave(seekerId: string, jobId: string): Promise<void> {
+        const ref = doc(db, COLLECTION, docId(seekerId, jobId));
+        await deleteDoc(ref);
+    },
+
+    async isSaved(seekerId: string, jobId: string): Promise<boolean> {
+        const ref = doc(db, COLLECTION, docId(seekerId, jobId));
+        const snap = await getDoc(ref);
+        return snap.exists();
+    },
+
+    async getSavedBySeeker(seekerId: string): Promise<JobPosting[]> {
+        const q = query(collection(db, COLLECTION), where('seekerId', '==', seekerId));
+        const snap = await getDocs(q);
+        return snap.docs.map(d => {
+            const data = d.data() as { snapshot: JobPosting; jobId: string };
+            return { ...data.snapshot, id: data.jobId };
+        });
+    },
+
+    async getSavedJobIds(seekerId: string): Promise<Set<string>> {
+        const q = query(collection(db, COLLECTION), where('seekerId', '==', seekerId));
+        const snap = await getDocs(q);
+        return new Set(snap.docs.map(d => (d.data() as { jobId: string }).jobId));
+    },
+};

--- a/src/features/seeker/services/shortlistService.ts
+++ b/src/features/seeker/services/shortlistService.ts
@@ -9,7 +9,8 @@ import {
     Timestamp,
     doc,
     getDoc,
-    writeBatch
+    writeBatch,
+    VectorValue
 } from "firebase/firestore";
 import { db } from "../../../lib/firebase";
 import * as Sentry from "@sentry/react";
@@ -221,11 +222,12 @@ export const ShortlistService = {
 
                 // 5. Score Candidates
                 const scoredJobs = candidates
-                    .filter((job): job is JobPosting & { embedding: number[] } =>
-                        Array.isArray(job.embedding) && job.embedding.length === userEmbedding.length
-                    )
+                    .filter((job): job is JobPosting & { embedding: number[] | VectorValue } => {
+                        if (job.embedding instanceof VectorValue) return job.embedding.toArray().length === userEmbedding.length;
+                        return Array.isArray(job.embedding) && job.embedding.length === userEmbedding.length;
+                    })
                     .map(job => {
-                        const embedding = job.embedding;
+                        const embedding = job.embedding instanceof VectorValue ? job.embedding.toArray() : job.embedding;
                         const score = cosineSimilarity(userEmbedding, embedding);
                         const matchContext = profileData ?? resumeData;
                         if (!matchContext) throw new Error("No user context for matching");

--- a/src/pages/BrownieLeaderboardPage.tsx
+++ b/src/pages/BrownieLeaderboardPage.tsx
@@ -1,0 +1,200 @@
+import React, { useEffect, useState } from 'react';
+import { useAuth } from '../hooks/useAuth';
+import { Header } from '../components/Header';
+import { db } from '../lib/firebase';
+import { collection, getDocs, orderBy, query, limit, where, getCountFromServer } from 'firebase/firestore';
+import { Trophy, Medal, Star, Loader2, Users } from 'lucide-react';
+
+interface LeaderEntry {
+    uid: string;
+    displayName: string;
+    browniePoints: number;
+    role: string;
+}
+
+const MEDALS = ['🥇', '🥈', '🥉'];
+
+const BrownieLeaderboardPage: React.FC = () => {
+    const { user, userData } = useAuth();
+    const [leaders, setLeaders] = useState<LeaderEntry[]>([]);
+    const [myRank, setMyRank] = useState<number | null>(null);
+    const [myPoints, setMyPoints] = useState<number>(0);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        const load = async () => {
+            try {
+                const snap = await getDocs(
+                    query(
+                        collection(db, 'leaderboard'),
+                        orderBy('browniePoints', 'desc'),
+                        limit(20)
+                    )
+                );
+
+                const entries: LeaderEntry[] = snap.docs.map(d => {
+                    const data = d.data();
+                    return {
+                        uid: d.id,
+                        displayName: (data['displayName'] as string | undefined) ?? 'Anonymous',
+                        browniePoints: typeof data['browniePoints'] === 'number' ? data['browniePoints'] : 0,
+                        role: (data['role'] as string | undefined) ?? 'seeker',
+                    };
+                });
+
+                setLeaders(entries);
+
+                // Compute current user's rank if not in top 20
+                if (user) {
+                    const currentPoints = typeof userData?.browniePoints === 'number' ? userData.browniePoints : 0;
+                    setMyPoints(currentPoints);
+
+                    const inTop = entries.findIndex(e => e.uid === user.uid);
+                    if (inTop !== -1) {
+                        setMyRank(inTop + 1);
+                    } else {
+                        // Count leaderboard entries with more points
+                        const aboveSnap = await getCountFromServer(
+                            query(collection(db, 'leaderboard'), where('browniePoints', '>', currentPoints))
+                        );
+                        setMyRank(aboveSnap.data().count + 1);
+                    }
+                }
+            } catch (err) {
+                console.error('[BrownieLeaderboard] load error:', err);
+            } finally {
+                setLoading(false);
+            }
+        };
+        void load();
+    }, [user, userData]);
+
+    const isInTopList = leaders.some(e => e.uid === user?.uid);
+
+    return (
+        <div className="min-h-screen bg-slate-50 flex flex-col font-sans">
+            <Header />
+
+            <main className="flex-grow container mx-auto px-4 md:px-8 py-12 max-w-2xl">
+                {/* Header */}
+                <div className="border-b border-slate-200 pb-8 mb-10 text-center">
+                    <div className="w-14 h-14 bg-amber-50 rounded-2xl border border-amber-100 flex items-center justify-center mx-auto mb-4">
+                        <Trophy className="w-7 h-7 text-amber-600" />
+                    </div>
+                    <h1 className="text-3xl font-bold text-slate-900">Brownie Points</h1>
+                    <p className="text-sm text-slate-400 mt-1">Top earners on WorkMila — earn points by referring friends and completing your profile</p>
+                </div>
+
+                {loading ? (
+                    <div className="flex items-center justify-center py-20">
+                        <Loader2 className="w-8 h-8 animate-spin text-amber-500" />
+                    </div>
+                ) : (
+                    <>
+                        {/* Your rank card (if logged in) */}
+                        {user && (
+                            <div className={`rounded-2xl border p-5 mb-8 flex items-center justify-between gap-4 ${
+                                isInTopList
+                                    ? 'bg-amber-50 border-amber-200'
+                                    : 'bg-white border-slate-200 shadow-soft'
+                            }`}>
+                                <div className="flex items-center gap-3">
+                                    <div className="w-10 h-10 rounded-xl bg-amber-100 border border-amber-200 flex items-center justify-center shrink-0">
+                                        <Star className="w-5 h-5 text-amber-600" />
+                                    </div>
+                                    <div>
+                                        <p className="text-sm font-semibold text-slate-900">{userData?.displayName ?? 'You'}</p>
+                                        <p className="text-xs text-slate-400">Your ranking</p>
+                                    </div>
+                                </div>
+                                <div className="text-right shrink-0">
+                                    <p className="text-2xl font-bold text-amber-600 tabular-nums">{myPoints.toLocaleString()}</p>
+                                    <p className="text-xs text-slate-400">
+                                        {myRank !== null ? `Rank #${myRank}` : '—'}
+                                    </p>
+                                </div>
+                            </div>
+                        )}
+
+                        {/* Leaderboard */}
+                        {leaders.length === 0 ? (
+                            <div className="bg-white rounded-2xl border border-dashed border-slate-200 p-16 text-center">
+                                <Users className="w-10 h-10 text-slate-300 mx-auto mb-3" />
+                                <p className="text-slate-500">No points earned yet. Be the first!</p>
+                            </div>
+                        ) : (
+                            <div className="bg-white rounded-2xl border border-slate-200 shadow-soft overflow-hidden">
+                                {leaders.map((entry, idx) => {
+                                    const isMe = entry.uid === user?.uid;
+                                    const medal = MEDALS[idx] ?? null;
+                                    return (
+                                        <div
+                                            key={entry.uid}
+                                            className={`flex items-center gap-4 px-5 py-4 border-b border-slate-50 last:border-0 transition-colors ${
+                                                isMe ? 'bg-amber-50' : 'hover:bg-slate-50'
+                                            }`}
+                                        >
+                                            {/* Rank */}
+                                            <div className="w-8 text-center shrink-0">
+                                                {medal
+                                                    ? <span className="text-xl">{medal}</span>
+                                                    : <span className="text-sm font-semibold text-slate-400 tabular-nums">{idx + 1}</span>
+                                                }
+                                            </div>
+
+                                            {/* Avatar */}
+                                            <div className="w-9 h-9 rounded-full bg-sky-50 border border-sky-100 flex items-center justify-center shrink-0">
+                                                <span className="text-sm font-bold text-sky-700">
+                                                    {entry.displayName.charAt(0).toUpperCase()}
+                                                </span>
+                                            </div>
+
+                                            {/* Name */}
+                                            <div className="flex-1 min-w-0">
+                                                <p className={`text-sm font-semibold truncate ${isMe ? 'text-amber-700' : 'text-slate-900'}`}>
+                                                    {entry.displayName}
+                                                    {isMe && <span className="ml-1.5 text-xs font-medium text-amber-500">(you)</span>}
+                                                </p>
+                                                <p className="text-xs text-slate-400 capitalize">{entry.role === 'seeker' ? 'Job Seeker' : entry.role === 'employer' ? 'Employer' : entry.role}</p>
+                                            </div>
+
+                                            {/* Points */}
+                                            <div className="flex items-center gap-1.5 shrink-0">
+                                                <Medal className="w-3.5 h-3.5 text-amber-400" />
+                                                <span className={`text-sm font-bold tabular-nums ${isMe ? 'text-amber-600' : 'text-slate-700'}`}>
+                                                    {entry.browniePoints.toLocaleString()}
+                                                </span>
+                                            </div>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        )}
+
+                        {/* How to earn */}
+                        <div className="mt-8 bg-white rounded-2xl border border-slate-200 shadow-soft p-6">
+                            <h3 className="text-sm font-semibold text-slate-900 mb-4 flex items-center gap-2">
+                                <Star className="w-4 h-4 text-amber-500" />
+                                How to Earn Points
+                            </h3>
+                            <div className="space-y-3">
+                                {[
+                                    { action: 'Refer a friend who registers', points: 50 },
+                                    { action: 'Complete your profile 100%', points: 20 },
+                                    { action: 'Verify your phone number', points: 10 },
+                                ].map(({ action, points }) => (
+                                    <div key={action} className="flex items-center justify-between text-sm">
+                                        <span className="text-slate-600">{action}</span>
+                                        <span className="font-semibold text-amber-600">+{points} pts</span>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    </>
+                )}
+            </main>
+        </div>
+    );
+};
+
+export default BrownieLeaderboardPage;

--- a/src/pages/JobDetailPage.tsx
+++ b/src/pages/JobDetailPage.tsx
@@ -206,7 +206,7 @@ export const JobDetailPage: React.FC = () => {
 
                     {/* Right Sidebar */}
                     <div className="lg:w-80 shrink-0">
-                        <div className="sticky top-24 space-y-4">
+                        <div className="lg:sticky lg:top-24 space-y-4">
                             {/* Apply Card */}
                             <div className="bg-white rounded-2xl border border-slate-200 shadow-soft p-6">
                                 {hasApplied ? (

--- a/src/pages/JobsPage.tsx
+++ b/src/pages/JobsPage.tsx
@@ -14,6 +14,7 @@ import { X } from 'lucide-react';
 import * as Sentry from '@sentry/react';
 import { searchJobs, getJobSuggestions } from '../lib/ai/search';
 import { useAuth } from '../hooks/useAuth';
+import { SavedJobsService } from '../features/seeker/services/savedJobsService';
 
 type JobWithMatch = Job & { matchScore?: number };
 
@@ -66,6 +67,8 @@ export const JobsPage: React.FC = () => {
     const [currentSearchQuery, setCurrentSearchQuery] = useState('');
     const [suggestions, setSuggestions] = useState<string[]>([]);
     const [applyingJob, setApplyingJob] = useState<JobPosting | null>(null);
+    const [savedJobIds, setSavedJobIds] = useState<Set<string>>(new Set());
+    const [saveInFlightIds, setSaveInFlightIds] = useState<Set<string>>(new Set());
 
     const userId = user?.uid ?? null;
 
@@ -90,6 +93,11 @@ export const JobsPage: React.FC = () => {
 
         void fetchJobs();
     }, [authLoading, userId]);
+
+    useEffect(() => {
+        if (!userId || !isSeeker) return;
+        void SavedJobsService.getSavedJobIds(userId).then(ids => { setSavedJobIds(ids); }).catch(() => { /* non-critical, saved state unavailable */ });
+    }, [userId, isSeeker]);
 
     const handleSearch = async (term: string, filters: Partial<JobSearchFilters>) => {
         const query = term;
@@ -162,6 +170,46 @@ export const JobsPage: React.FC = () => {
         setDisplayedJobs(browseJobs);
         setSuggestions([]);
         setError(null);
+    };
+
+    const handleSaveJob = async (jobId: string) => {
+        if (!userId) return;
+        if (saveInFlightIds.has(jobId)) return;
+
+        setSaveInFlightIds(prev => new Set([...prev, jobId]));
+        const wasSaved = savedJobIds.has(jobId);
+        if (wasSaved) {
+            setSavedJobIds(prev => { const next = new Set(prev); next.delete(jobId); return next; });
+        } else {
+            setSavedJobIds(prev => new Set([...prev, jobId]));
+        }
+
+        const isSaved = savedJobIds.has(jobId);
+        try {
+            if (isSaved) {
+                await SavedJobsService.unsave(userId, jobId);
+            } else {
+                const posting = await JobService.getJobById(jobId);
+                if (!posting) {
+                    throw new Error('Job not found while saving');
+                }
+                await SavedJobsService.save(userId, posting);
+            }
+        } catch (err) {
+            console.error('[JobsPage] save toggle failed:', err);
+            setSavedJobIds(prev => {
+                const next = new Set(prev);
+                if (wasSaved) next.add(jobId);
+                else next.delete(jobId);
+                return next;
+            });
+        } finally {
+            setSaveInFlightIds(prev => {
+                const next = new Set(prev);
+                next.delete(jobId);
+                return next;
+            });
+        }
     };
 
     const handleApply = async (jobId: string) => {
@@ -335,6 +383,8 @@ export const JobsPage: React.FC = () => {
                                     matchScore={job.matchScore}
                                     onClick={() => navigate(`/jobs/${job.id}`)}
                                     onApply={isSeeker ? (e) => { e.stopPropagation(); void handleApply(job.id); } : undefined}
+                                    onSave={isSeeker ? (e: React.MouseEvent) => { e.stopPropagation(); void handleSaveJob(job.id); } : undefined}
+                                    isSaved={savedJobIds.has(job.id)}
                                 />
                             ))}
                         </div>
@@ -345,7 +395,7 @@ export const JobsPage: React.FC = () => {
             {applyingJob && (
                 <ApplyModal
                     job={applyingJob}
-                    isOpen={true}
+                    isOpen={!!applyingJob}
                     onClose={() => { setApplyingJob(null); }}
                 />
             )}

--- a/src/pages/PostJob.tsx
+++ b/src/pages/PostJob.tsx
@@ -217,7 +217,7 @@ export const PostJob: React.FC = () => {
     }));
   };
 
-  const inputClasses = "w-full px-4 py-2.5 border border-slate-200 bg-white text-sm rounded-lg focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-transparent transition-all placeholder:text-slate-400";
+  const inputClasses = "w-full px-4 py-2.5 border border-slate-200 bg-white text-sm text-slate-900 rounded-lg focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-transparent transition-all placeholder:text-slate-400";
   const labelClasses = "text-xs font-medium text-slate-500 mb-1.5 block";
 
   return (
@@ -260,7 +260,7 @@ export const PostJob: React.FC = () => {
                 value={formData.title}
                 onChange={handleChange}
                 placeholder="e.g. Senior Frontend Engineer"
-                className="w-full bg-transparent border-b-2 border-white/30 focus:border-white text-2xl font-bold focus:outline-none placeholder:text-white/30 py-2 transition-colors"
+                className="w-full bg-transparent border-b-2 border-white/30 focus:border-white text-xl md:text-2xl font-bold focus:outline-none placeholder:text-white/30 py-2 transition-colors"
               />
             </div>
           </div>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -21,7 +21,7 @@ const ROLE_LABEL: Record<string, string> = {
 };
 
 export const SettingsPage: React.FC = () => {
-    const { user, userData, updateDisplayName, deleteAccount, resetPassword, logout, clearError, error: authError } = useAuth();
+    const { user, userData, updateDisplayName, verifyEmailUpdate, deleteAccount, resetPassword, logout, clearError, error: authError } = useAuth();
     const navigate = useNavigate();
 
     const [editingName, setEditingName] = useState(false);
@@ -38,6 +38,11 @@ export const SettingsPage: React.FC = () => {
 
     const [resetLoading, setResetLoading] = useState(false);
     const [resetSent, setResetSent] = useState(false);
+
+    const [emailEditing, setEmailEditing] = useState(false);
+    const [newEmail, setNewEmail] = useState('');
+    const [emailLoading, setEmailLoading] = useState(false);
+    const [emailSent, setEmailSent] = useState(false);
 
     const [deletePhase, setDeletePhase] = useState<'idle' | 'confirm'>('idle');
     const [deleteLoading, setDeleteLoading] = useState(false);
@@ -66,6 +71,24 @@ export const SettingsPage: React.FC = () => {
             setLocalError('Failed to update name. Please try again.');
         } finally {
             setNameLoading(false);
+        }
+    };
+
+    const handleEmailUpdate = async () => {
+        const trimmed = newEmail.trim();
+        if (!trimmed || trimmed === user?.email) return;
+        setEmailLoading(true);
+        setLocalError(null);
+        clearError();
+        try {
+            await verifyEmailUpdate(trimmed);
+            setEmailSent(true);
+            setEmailEditing(false);
+            setNewEmail('');
+        } catch {
+            // authError synced via useEffect
+        } finally {
+            setEmailLoading(false);
         }
     };
 
@@ -180,7 +203,55 @@ export const SettingsPage: React.FC = () => {
                             <div className="block text-xs font-medium text-slate-500 uppercase tracking-widest mb-1.5 flex items-center gap-1.5">
                                 <Mail className="w-3 h-3" /> Email
                             </div>
-                            <span className="text-sm text-slate-800">{user?.email ?? '—'}</span>
+                            {emailSent ? (
+                                <div className="flex items-center gap-2 p-3 bg-emerald-50 border border-emerald-100 rounded-xl text-sm text-emerald-700">
+                                    <Check className="w-4 h-4 shrink-0" />
+                                    Verification link sent to your new email. Click it to confirm the change.
+                                </div>
+                            ) : emailEditing ? (
+                                <div className="space-y-2">
+                                    <div className="flex items-center gap-2">
+                                        <input
+                                            type="email"
+                                            value={newEmail}
+                                            onChange={(e) => { setNewEmail(e.target.value); }}
+                                            onKeyDown={(e) => {
+                                                if (e.key === 'Enter') { void handleEmailUpdate(); }
+                                                if (e.key === 'Escape') { setEmailEditing(false); setNewEmail(''); }
+                                            }}
+                                            placeholder="New email address"
+                                            className="flex-grow px-4 py-2.5 border border-slate-200 rounded-lg text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-sky-500 transition-all"
+                                            // eslint-disable-next-line jsx-a11y/no-autofocus
+                                            autoFocus
+                                        />
+                                        <button
+                                            onClick={() => { void handleEmailUpdate(); }}
+                                            disabled={emailLoading || !newEmail.trim()}
+                                            className="flex items-center justify-center w-9 h-9 bg-sky-700 hover:bg-sky-800 text-white rounded-lg transition-colors disabled:opacity-50"
+                                        >
+                                            {emailLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Check className="w-4 h-4" />}
+                                        </button>
+                                        <button
+                                            onClick={() => { setEmailEditing(false); setNewEmail(''); }}
+                                            className="flex items-center justify-center w-9 h-9 border border-slate-200 text-slate-400 hover:text-slate-600 rounded-lg transition-colors"
+                                        >
+                                            <X className="w-4 h-4" />
+                                        </button>
+                                    </div>
+                                    <p className="text-xs text-slate-400">A verification link will be sent to the new address. Your email won't change until you click it.</p>
+                                </div>
+                            ) : (
+                                <div className="flex items-center justify-between">
+                                    <span className="text-sm text-slate-800">{user?.email ?? '—'}</span>
+                                    <button
+                                        onClick={() => { setEmailEditing(true); }}
+                                        className="flex items-center gap-1.5 text-xs text-sky-600 hover:text-sky-800 font-medium transition-colors"
+                                    >
+                                        <Pencil className="w-3.5 h-3.5" />
+                                        Change
+                                    </button>
+                                </div>
+                            )}
                         </div>
 
                         {/* Role */}

--- a/src/pages/admin/AdminDashboard.tsx
+++ b/src/pages/admin/AdminDashboard.tsx
@@ -1,98 +1,162 @@
-import { Users, Briefcase, FileText, ArrowUpRight, ArrowDownRight } from 'lucide-react';
+import React, { useEffect, useState } from 'react';
+import { Users, Briefcase, FileText, Loader2 } from 'lucide-react';
+import { db } from '../../lib/firebase';
+import {
+    collection, getCountFromServer, query, where,
+    getDocs, orderBy, limit, Timestamp,
+} from 'firebase/firestore';
+
+interface LiveStats {
+    totalUsers: number;
+    activeJobs: number;
+    totalApplications: number;
+}
+
+interface RecentItem {
+    id: string;
+    text: string;
+    sub: string;
+}
+
+interface HealthStatus {
+    label: string;
+    status: 'healthy' | 'unhealthy';
+    detail: string;
+}
 
 const AdminDashboard = () => {
-  const stats = [
-    { name: 'Total Users', value: '1,284', icon: Users, change: '+12%', changeType: 'increase' },
-    { name: 'Active Jobs', value: '156', icon: Briefcase, change: '+5%', changeType: 'increase' },
-    { name: 'Total Applications', value: '4,320', icon: FileText, change: '-2%', changeType: 'decrease' },
-  ];
+    const [stats, setStats] = useState<LiveStats | null>(null);
+    const [recentActivity, setRecentActivity] = useState<RecentItem[]>([]);
+    const [healthStatuses, setHealthStatuses] = useState<HealthStatus[]>([
+        { label: 'Firebase Auth', status: 'unhealthy', detail: 'Status checks coming soon' },
+        { label: 'Firestore', status: 'unhealthy', detail: 'Status checks coming soon' },
+        { label: 'AI Proxy (Express)', status: 'unhealthy', detail: 'Status checks coming soon' },
+    ]);
+    const [loading, setLoading] = useState(true);
 
-  return (
-    <div className="space-y-8 font-sans">
-      <div className="border-b border-slate-200 pb-6">
-        <h2 className="text-2xl font-bold text-slate-900 mb-1">Dashboard Overview</h2>
-        <p className="text-xs font-medium text-slate-400">Super Admin Control Center</p>
-      </div>
+    useEffect(() => {
+        const load = async () => {
+            try {
+                const [userSnap, jobSnap, appSnap] = await Promise.all([
+                    getCountFromServer(collection(db, 'users')),
+                    getCountFromServer(query(collection(db, 'jobs'), where('status', '==', 'active'))),
+                    getCountFromServer(collection(db, 'applications')),
+                ]);
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
-        {stats.map((stat) => (
-          <div key={stat.name} className="bg-white rounded-xl border border-slate-200 p-6 shadow-soft hover:shadow-soft-md hover:border-sky-200 transition-all duration-200">
-            <div className="flex items-start justify-between mb-5">
-              <div className="w-10 h-10 bg-sky-50 text-sky-700 rounded-lg flex items-center justify-center">
-                <stat.icon size={20} strokeWidth={1.5} />
-              </div>
-              <div className={`flex items-center gap-1 text-xs font-semibold px-2.5 py-1 rounded-full ${
-                stat.changeType === 'increase' ? 'bg-emerald-100 text-emerald-700' : 'bg-red-100 text-red-600'
-              }`}>
-                {stat.change}
-                {stat.changeType === 'increase' ? <ArrowUpRight size={12} /> : <ArrowDownRight size={12} />}
-              </div>
+                setStats({
+                    totalUsers: userSnap.data().count,
+                    activeJobs: jobSnap.data().count,
+                    totalApplications: appSnap.data().count,
+                });
+
+                // Recent activity: latest 5 users
+                const recentUsersSnap = await getDocs(
+                    query(collection(db, 'users'), orderBy('createdAt', 'desc'), limit(5))
+                );
+                const items: RecentItem[] = recentUsersSnap.docs.map(d => {
+                    const data = d.data() as { displayName?: string; email?: string; role?: string; createdAt?: Timestamp };
+                    const name = data.displayName ?? data.email ?? 'Anonymous';
+                    const role = data.role ?? 'user';
+                    const ts = data.createdAt instanceof Timestamp
+                        ? data.createdAt.toDate().toLocaleDateString()
+                        : 'Recently';
+                    return { id: d.id, text: `New ${role} registered: ${name}`, sub: ts };
+                });
+                setRecentActivity(items);
+                setHealthStatuses([
+                    { label: 'Firebase Auth', status: 'unhealthy', detail: 'Status checks coming soon' },
+                    { label: 'Firestore', status: 'unhealthy', detail: 'Status checks coming soon' },
+                    { label: 'AI Proxy (Express)', status: 'unhealthy', detail: 'Status checks coming soon' },
+                ]);
+            } catch (err) {
+                console.error('[AdminDashboard] stats load error:', err);
+            } finally {
+                setLoading(false);
+            }
+        };
+        void load();
+    }, []);
+
+    const kpis = stats ? [
+        { name: 'Total Users', value: stats.totalUsers.toLocaleString(), icon: Users },
+        { name: 'Active Jobs', value: stats.activeJobs.toLocaleString(), icon: Briefcase },
+        { name: 'Total Applications', value: stats.totalApplications.toLocaleString(), icon: FileText },
+    ] : [];
+
+    return (
+        <div className="space-y-8 font-sans">
+            <div className="border-b border-slate-200 pb-6">
+                <h2 className="text-2xl font-bold text-slate-900 mb-1">Dashboard Overview</h2>
+                <p className="text-xs font-medium text-slate-400">Super Admin Control Center · Live Data</p>
             </div>
-            <div className="text-3xl font-bold text-slate-900 tabular-nums mb-1">{stat.value}</div>
-            <div className="text-xs font-medium text-slate-400">{stat.name}</div>
-          </div>
-        ))}
-      </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
-        <div className="bg-white rounded-xl border border-slate-200 shadow-soft p-6">
-          <h3 className="text-base font-semibold text-slate-900 mb-5 flex items-center gap-2">
-            <span className="w-2 h-2 bg-sky-600 rounded-full"></span>
-            Recent Activity
-          </h3>
-          <div className="space-y-0">
-            {[1, 2, 3].map((i) => (
-              <div key={i} className="flex items-start gap-3 py-3.5 border-b border-slate-100 last:border-0">
-                <div className="w-2 h-2 mt-1.5 bg-sky-400 rounded-full flex-shrink-0" />
-                <div>
-                  <p className="text-sm font-medium text-slate-800">New employer registration: <span className="text-slate-500 font-normal">TechCorp Ltd.</span></p>
-                  <p className="text-xs text-slate-400 mt-0.5">2 hours ago</p>
+            {loading ? (
+                <div className="flex items-center justify-center py-20">
+                    <Loader2 className="w-7 h-7 animate-spin text-sky-600" />
                 </div>
-              </div>
-            ))}
-          </div>
+            ) : (
+                <>
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+                        {kpis.map((stat) => (
+                            <div key={stat.name} className="bg-white rounded-xl border border-slate-200 p-6 shadow-soft hover:shadow-soft-md hover:border-sky-200 transition-all duration-200">
+                                <div className="flex items-start justify-between mb-5">
+                                    <div className="w-10 h-10 bg-sky-50 text-sky-700 rounded-lg flex items-center justify-center">
+                                        <stat.icon size={20} strokeWidth={1.5} />
+                                    </div>
+                                </div>
+                                <div className="text-3xl font-bold text-slate-900 tabular-nums mb-1">{stat.value}</div>
+                                <div className="text-xs font-medium text-slate-400">{stat.name}</div>
+                            </div>
+                        ))}
+                    </div>
+
+                    <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+                        <div className="bg-white rounded-xl border border-slate-200 shadow-soft p-6">
+                            <h3 className="text-base font-semibold text-slate-900 mb-5 flex items-center gap-2">
+                                <span className="w-2 h-2 bg-sky-600 rounded-full"></span>
+                                Recent Registrations
+                            </h3>
+                            {recentActivity.length === 0 ? (
+                                <p className="text-sm text-slate-400">No recent activity.</p>
+                            ) : (
+                                <div className="space-y-0">
+                                    {recentActivity.map((item) => (
+                                        <div key={item.id} className="flex items-start gap-3 py-3.5 border-b border-slate-100 last:border-0">
+                                            <div className="w-2 h-2 mt-1.5 bg-sky-400 rounded-full flex-shrink-0" />
+                                            <div>
+                                                <p className="text-sm font-medium text-slate-800">{item.text}</p>
+                                                <p className="text-xs text-slate-400 mt-0.5">{item.sub}</p>
+                                            </div>
+                                        </div>
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+
+                        <div className="bg-white rounded-xl border border-slate-200 shadow-soft p-6">
+                            <h3 className="text-base font-semibold text-slate-900 mb-5 flex items-center gap-2">
+                                <span className="w-2 h-2 bg-sky-600 rounded-full"></span>
+                                System Health
+                            </h3>
+                            <div className="space-y-5">
+                                {healthStatuses.map((item) => (
+                                    <div key={item.label} className="space-y-2">
+                                        <div className="flex items-center justify-between text-xs font-medium">
+                                            <span className="text-slate-600">{item.label}</span>
+                                            <span className="bg-amber-100 text-amber-700 px-2 py-0.5 rounded-full font-semibold">
+                                                Placeholder
+                                            </span>
+                                        </div>
+                                        <p className="text-xs text-slate-400">{item.detail}</p>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    </div>
+                </>
+            )}
         </div>
-
-        <div className="bg-white rounded-xl border border-slate-200 shadow-soft p-6">
-          <h3 className="text-base font-semibold text-slate-900 mb-5 flex items-center gap-2">
-            <span className="w-2 h-2 bg-sky-600 rounded-full"></span>
-            System Health
-          </h3>
-          <div className="space-y-5">
-            <div className="space-y-2">
-              <div className="flex items-center justify-between text-xs font-medium">
-                <span className="text-slate-600">API Latency</span>
-                <span className="bg-sky-100 text-sky-700 px-2 py-0.5 rounded-full font-semibold">42ms</span>
-              </div>
-              <div className="w-full h-2 bg-slate-100 rounded-full overflow-hidden">
-                <div className="h-full bg-sky-500 rounded-full w-[95%]"></div>
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <div className="flex items-center justify-between text-xs font-medium">
-                <span className="text-slate-600">Search Engine Sync</span>
-                <span className="bg-emerald-100 text-emerald-700 px-2 py-0.5 rounded-full font-semibold">Operational</span>
-              </div>
-              <div className="w-full h-2 bg-emerald-100 rounded-full overflow-hidden">
-                <div className="h-full bg-emerald-500 rounded-full w-full"></div>
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <div className="flex items-center justify-between text-xs font-medium">
-                <span className="text-slate-600">Database Load</span>
-                <span className="text-slate-500 font-semibold">64%</span>
-              </div>
-              <div className="w-full h-2 bg-slate-100 rounded-full overflow-hidden">
-                <div className="h-full bg-amber-400 rounded-full w-[64%]"></div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+    );
 };
 
 export default AdminDashboard;

--- a/src/pages/admin/AdminSettingsPage.tsx
+++ b/src/pages/admin/AdminSettingsPage.tsx
@@ -1,0 +1,204 @@
+import React, { useEffect, useState } from 'react';
+import {
+    Settings, Save, Loader2, Check, AlertTriangle,
+    ToggleLeft, ToggleRight, Percent,
+} from 'lucide-react';
+import { db } from '../../lib/firebase';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+
+interface PlatformConfig {
+    platformFeePercent: number;
+    featureFlags: {
+        referralEnabled: boolean;
+        aiMatchingEnabled: boolean;
+        browniePointsEnabled: boolean;
+        emailVerificationRequired: boolean;
+    };
+}
+
+const DEFAULT_CONFIG: PlatformConfig = {
+    platformFeePercent: 10,
+    featureFlags: {
+        referralEnabled: true,
+        aiMatchingEnabled: true,
+        browniePointsEnabled: true,
+        emailVerificationRequired: true,
+    },
+};
+
+const CONFIG_DOC = 'config/platform';
+
+function mergePlatformConfig(defaults: PlatformConfig, incoming?: Partial<PlatformConfig>): PlatformConfig {
+    return {
+        ...defaults,
+        ...incoming,
+        featureFlags: {
+            ...defaults.featureFlags,
+            ...(incoming?.featureFlags ?? {}),
+        },
+    };
+}
+
+const AdminSettingsPage: React.FC = () => {
+    const [config, setConfig] = useState<PlatformConfig>(DEFAULT_CONFIG);
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+    const [success, setSuccess] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const load = async () => {
+            try {
+                const snap = await getDoc(doc(db, CONFIG_DOC));
+                if (snap.exists()) {
+                    const merged = mergePlatformConfig(DEFAULT_CONFIG, snap.data() as Partial<PlatformConfig>);
+                    setConfig(merged);
+                }
+            } catch (err) {
+                console.error('[AdminSettingsPage] load error:', err);
+            } finally {
+                setLoading(false);
+            }
+        };
+        void load();
+    }, []);
+
+    const handleSave = async () => {
+        setSaving(true);
+        setError(null);
+        try {
+            await setDoc(doc(db, CONFIG_DOC), config);
+            setSuccess(true);
+            setTimeout(() => { setSuccess(false); }, 3000);
+        } catch (err) {
+            console.error('[AdminSettingsPage] save error:', err);
+            setError('Failed to save settings. Please try again.');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const toggleFlag = (flag: keyof PlatformConfig['featureFlags']) => {
+        setConfig(prev => ({
+            ...prev,
+            featureFlags: { ...prev.featureFlags, [flag]: !prev.featureFlags[flag] },
+        }));
+    };
+
+    const FLAG_META: { key: keyof PlatformConfig['featureFlags']; label: string; description: string }[] = [
+        { key: 'referralEnabled', label: 'Referral Program', description: 'Allow users to share referral codes and earn Brownie Points' },
+        { key: 'aiMatchingEnabled', label: 'AI Job Matching', description: 'Enable semantic job matching and daily shortlists for seekers' },
+        { key: 'browniePointsEnabled', label: 'Brownie Points', description: 'Enable the gamification points ledger across the platform' },
+        { key: 'emailVerificationRequired', label: 'Email Verification Required', description: 'Block access until users verify their email address' },
+    ];
+
+    if (loading) {
+        return (
+            <div className="flex items-center justify-center py-20">
+                <Loader2 className="w-7 h-7 animate-spin text-sky-600" />
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-8 font-sans max-w-2xl">
+            <div className="border-b border-slate-200 pb-6">
+                <span className="text-xs font-semibold text-sky-600 uppercase tracking-widest block mb-1">Admin</span>
+                <h2 className="text-2xl font-bold text-slate-900 flex items-center gap-2">
+                    <Settings className="w-6 h-6 text-sky-700" />
+                    Platform Settings
+                </h2>
+                <p className="text-xs text-slate-400 mt-0.5">Configure platform-wide settings and feature flags</p>
+            </div>
+
+            {error && (
+                <div className="p-4 rounded-xl border border-red-100 bg-red-50 flex items-center gap-3 text-sm text-red-600">
+                    <AlertTriangle className="w-4 h-4 shrink-0" />
+                    {error}
+                </div>
+            )}
+
+            {success && (
+                <div className="p-4 rounded-xl border border-emerald-100 bg-emerald-50 flex items-center gap-2 text-sm text-emerald-700">
+                    <Check className="w-4 h-4 shrink-0" />
+                    Settings saved successfully.
+                </div>
+            )}
+
+            {/* Platform fee */}
+            <section className="bg-white rounded-2xl border border-slate-200 shadow-soft p-6">
+                <h3 className="text-sm font-semibold text-slate-900 mb-4 flex items-center gap-2">
+                    <Percent className="w-4 h-4 text-sky-600" />
+                    Platform Fee
+                </h3>
+                <div>
+                    <label htmlFor="feePercent" className="text-xs font-medium text-slate-500 uppercase tracking-widest mb-1.5 block">
+                        Fee Percentage (%)
+                    </label>
+                    <div className="flex items-center gap-3">
+                        <input
+                            id="feePercent"
+                            type="number"
+                            min={0}
+                            max={100}
+                            step={0.5}
+                            value={config.platformFeePercent}
+                            onChange={(e) => {
+                                const raw = e.target.value;
+                                const parsed = Number.parseFloat(raw);
+                                if (!Number.isFinite(parsed)) {
+                                    setConfig((prev) => ({ ...prev, platformFeePercent: prev.platformFeePercent }));
+                                    return;
+                                }
+                                const clamped = Math.min(100, Math.max(0, parsed));
+                                const snapped = Math.round(clamped * 2) / 2;
+                                setConfig((prev) => ({ ...prev, platformFeePercent: snapped }));
+                            }}
+                            className="w-32 px-4 py-2.5 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-sky-500 transition-all"
+                        />
+                        <span className="text-sm text-slate-500">% of transaction value</span>
+                    </div>
+                </div>
+            </section>
+
+            {/* Feature flags */}
+            <section className="bg-white rounded-2xl border border-slate-200 shadow-soft p-6">
+                <h3 className="text-sm font-semibold text-slate-900 mb-5 flex items-center gap-2">
+                    <Settings className="w-4 h-4 text-sky-600" />
+                    Feature Flags
+                </h3>
+                <div className="space-y-4">
+                    {FLAG_META.map(({ key, label, description }) => (
+                        <div key={key} className="flex items-center justify-between gap-4 py-3 border-b border-slate-50 last:border-0">
+                            <div>
+                                <p className="text-sm font-semibold text-slate-800">{label}</p>
+                                <p className="text-xs text-slate-400 mt-0.5">{description}</p>
+                            </div>
+                            <button
+                                onClick={() => { toggleFlag(key); }}
+                                className={`shrink-0 transition-colors ${config.featureFlags[key] ? 'text-sky-600' : 'text-slate-300'}`}
+                                aria-label={`Toggle ${label}`}
+                            >
+                                {config.featureFlags[key]
+                                    ? <ToggleRight className="w-8 h-8" />
+                                    : <ToggleLeft className="w-8 h-8" />
+                                }
+                            </button>
+                        </div>
+                    ))}
+                </div>
+            </section>
+
+            <button
+                onClick={() => { void handleSave(); }}
+                disabled={saving}
+                className="flex items-center gap-2 px-6 py-3 bg-sky-700 hover:bg-sky-800 text-white font-semibold text-sm rounded-xl transition-colors disabled:opacity-50"
+            >
+                {saving ? <Loader2 className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4" />}
+                Save Settings
+            </button>
+        </div>
+    );
+};
+
+export default AdminSettingsPage;

--- a/src/pages/admin/AdminUsersPage.tsx
+++ b/src/pages/admin/AdminUsersPage.tsx
@@ -1,0 +1,201 @@
+import React, { useEffect, useState } from 'react';
+import {
+    Users, Search, Loader2, ShieldCheck, Briefcase, User,
+    RefreshCw, ChevronDown,
+} from 'lucide-react';
+import { db } from '../../lib/firebase';
+import { collection, getDocs, orderBy, query, Timestamp, limit, startAfter, type QueryDocumentSnapshot } from 'firebase/firestore';
+import type { UserData } from '../../context/AuthContext';
+
+type UserRow = UserData & { createdAt?: Timestamp };
+
+const ROLE_LABEL: Record<string, string> = {
+    seeker: 'Job Seeker',
+    employer: 'Employer',
+    admin: 'Admin',
+};
+
+const ROLE_BADGE: Record<string, string> = {
+    seeker: 'bg-sky-50 text-sky-700 border-sky-100',
+    employer: 'bg-violet-50 text-violet-700 border-violet-100',
+    admin: 'bg-amber-50 text-amber-700 border-amber-100',
+};
+
+const AdminUsersPage: React.FC = () => {
+    const [users, setUsers] = useState<UserRow[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [search, setSearch] = useState('');
+    const [roleFilter, setRoleFilter] = useState<'all' | 'seeker' | 'employer' | 'admin'>('all');
+    const [loadError, setLoadError] = useState<string | null>(null);
+    const [lastVisibleDoc, setLastVisibleDoc] = useState<QueryDocumentSnapshot | null>(null);
+    const [isLastPage, setIsLastPage] = useState(false);
+
+    const PAGE_SIZE = 50;
+
+    const load = async (append = false) => {
+        setLoading(true);
+        setLoadError(null);
+        try {
+            let usersQuery = query(
+                collection(db, 'users'),
+                orderBy('createdAt', 'desc'),
+                limit(PAGE_SIZE),
+            );
+            if (append && lastVisibleDoc) {
+                usersQuery = query(
+                    collection(db, 'users'),
+                    orderBy('createdAt', 'desc'),
+                    startAfter(lastVisibleDoc),
+                    limit(PAGE_SIZE),
+                );
+            }
+
+            const snap = await getDocs(usersQuery);
+            const newRows = snap.docs.map(d => ({ uid: d.id, ...d.data() } as UserRow));
+            setUsers(prev => append ? [...prev, ...newRows] : newRows);
+            setLastVisibleDoc(snap.docs[snap.docs.length - 1] ?? null);
+            setIsLastPage(snap.docs.length < PAGE_SIZE);
+        } catch (err) {
+            console.error('[AdminUsersPage] load error:', err);
+            setLoadError('Failed to load users. Please retry.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => { void load(false); }, []);
+
+    const filtered = users.filter(u => {
+        const matchRole = roleFilter === 'all' || u.role === roleFilter;
+        const term = search.toLowerCase();
+        const matchSearch = !term
+            || (u.displayName ?? '').toLowerCase().includes(term)
+            || (u.email ?? '').toLowerCase().includes(term);
+        return matchRole && matchSearch;
+    });
+
+    return (
+        <div className="space-y-6 font-sans">
+            <div className="border-b border-slate-200 pb-6 flex flex-col sm:flex-row justify-between items-start sm:items-end gap-4">
+                <div>
+                    <span className="text-xs font-semibold text-sky-600 uppercase tracking-widest block mb-1">Admin</span>
+                    <h2 className="text-2xl font-bold text-slate-900">User Management</h2>
+                    <p className="text-xs text-slate-400 mt-0.5">{users.length} total accounts</p>
+                </div>
+                <button
+                    onClick={() => { void load(false); }}
+                    className="flex items-center gap-1.5 px-4 py-2 text-xs font-semibold text-slate-600 bg-white border border-slate-200 rounded-xl hover:bg-slate-50 transition-colors"
+                >
+                    <RefreshCw className="w-3.5 h-3.5" /> Refresh
+                </button>
+            </div>
+
+            {/* Filters */}
+            <div className="flex flex-col sm:flex-row gap-3">
+                <div className="relative flex-1 max-w-sm">
+                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+                    <input
+                        type="text"
+                        value={search}
+                        onChange={(e) => { setSearch(e.target.value); }}
+                        placeholder="Search by name or email..."
+                        className="w-full pl-9 pr-4 py-2.5 text-sm border border-slate-200 rounded-xl bg-white focus:outline-none focus:ring-2 focus:ring-sky-500 transition-all"
+                    />
+                </div>
+                <div className="relative">
+                    <select
+                        value={roleFilter}
+                        onChange={(e) => { setRoleFilter(e.target.value as typeof roleFilter); }}
+                        className="pl-4 pr-8 py-2.5 text-sm border border-slate-200 rounded-xl bg-white text-slate-700 font-medium focus:outline-none focus:ring-2 focus:ring-sky-500 transition-all appearance-none"
+                    >
+                        <option value="all">All Roles</option>
+                        <option value="seeker">Job Seekers</option>
+                        <option value="employer">Employers</option>
+                        <option value="admin">Admins</option>
+                    </select>
+                    <ChevronDown className="absolute right-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 pointer-events-none" />
+                </div>
+            </div>
+
+            {loading ? (
+                <div className="flex flex-col items-center justify-center py-20 gap-3">
+                    <Loader2 className="w-7 h-7 animate-spin text-sky-600" />
+                    <p className="text-sm text-slate-400">Loading users...</p>
+                </div>
+            ) : loadError ? (
+                <div className="bg-white rounded-2xl border border-red-200 p-8 text-center">
+                    <p className="text-red-600 font-semibold">{loadError}</p>
+                </div>
+            ) : filtered.length === 0 ? (
+                <div className="bg-white rounded-2xl border border-dashed border-slate-200 p-16 text-center">
+                    <Users className="w-10 h-10 text-slate-300 mx-auto mb-3" />
+                    <p className="text-slate-500 font-semibold">No users found</p>
+                </div>
+            ) : (
+                <div className="bg-white rounded-2xl border border-slate-200 shadow-soft overflow-hidden">
+                    <table className="w-full text-sm">
+                        <thead>
+                            <tr className="border-b border-slate-100 bg-slate-50">
+                                <th className="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-widest">User</th>
+                                <th className="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-widest">Role</th>
+                                <th className="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-widest hidden md:table-cell">Verified</th>
+                                <th className="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-widest hidden lg:table-cell">Joined</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {filtered.map(u => (
+                                <tr key={u.uid} className="border-b border-slate-50 last:border-0 hover:bg-slate-50 transition-colors">
+                                    <td className="px-5 py-3.5">
+                                        <div className="flex items-center gap-3">
+                                            <div className="w-8 h-8 rounded-full bg-sky-50 border border-sky-100 flex items-center justify-center shrink-0">
+                                                {u.role === 'employer'
+                                                    ? <Briefcase className="w-3.5 h-3.5 text-violet-600" />
+                                                    : u.role === 'admin'
+                                                        ? <ShieldCheck className="w-3.5 h-3.5 text-amber-600" />
+                                                        : <User className="w-3.5 h-3.5 text-sky-600" />
+                                                }
+                                            </div>
+                                            <div>
+                                                <p className="font-semibold text-slate-900 leading-tight">{u.displayName ?? '—'}</p>
+                                                <p className="text-xs text-slate-400 mt-0.5">{u.email ?? '—'}</p>
+                                            </div>
+                                        </div>
+                                    </td>
+                                    <td className="px-5 py-3.5">
+                                        <span className={`inline-flex px-2.5 py-0.5 text-[11px] font-semibold rounded-full border capitalize ${ROLE_BADGE[u.role ?? ''] ?? 'bg-slate-100 text-slate-500 border-slate-200'}`}>
+                                            {u.role ? ROLE_LABEL[u.role] : 'Unknown'}
+                                        </span>
+                                    </td>
+                                    <td className="px-5 py-3.5 hidden md:table-cell">
+                                        {u.phoneVerified
+                                            ? <span className="text-xs text-emerald-600 font-medium">Phone ✓</span>
+                                            : <span className="text-xs text-slate-300">—</span>
+                                        }
+                                    </td>
+                                    <td className="px-5 py-3.5 text-xs text-slate-400 hidden lg:table-cell">
+                                        {u.createdAt instanceof Timestamp
+                                            ? u.createdAt.toDate().toLocaleDateString()
+                                            : '—'
+                                        }
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                    {!isLastPage && (
+                        <div className="p-4 border-t border-slate-100 text-center">
+                            <button
+                                onClick={() => { void load(true); }}
+                                className="px-4 py-2 text-xs font-semibold text-slate-700 bg-white border border-slate-200 rounded-xl hover:bg-slate-50 transition-colors"
+                            >
+                                Load More
+                            </button>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default AdminUsersPage;

--- a/src/pages/seeker/Dashboard.tsx
+++ b/src/pages/seeker/Dashboard.tsx
@@ -9,7 +9,9 @@ import {
     Video,
     ShieldCheck,
     ChevronRight,
-    Gift
+    Gift,
+    Bookmark,
+    Bell,
 } from 'lucide-react';
 
 import { getLatestResume } from '../../features/seeker/services/resumeService';
@@ -155,7 +157,7 @@ export const SeekerDashboard: React.FC = () => {
                         </div>
                     </header>
 
-                    <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                         {/* LEFT COLUMN: Core Insights */}
                         <div className="lg:col-span-2 space-y-8">
 
@@ -349,6 +351,20 @@ export const SeekerDashboard: React.FC = () => {
                                     title="App Tracker"
                                     description="Kanban Board"
                                     onClick={() => navigate('/seeker/tracker')}
+                                />
+
+                                <ToolLink
+                                    icon={<Bookmark className="w-5 h-5" />}
+                                    title="Saved Jobs"
+                                    description="Bookmarked for later"
+                                    onClick={() => navigate('/seeker/saved')}
+                                />
+
+                                <ToolLink
+                                    icon={<Bell className="w-5 h-5" />}
+                                    title="Job Alerts"
+                                    description="Get notified for new matches"
+                                    onClick={() => navigate('/seeker/alerts')}
                                 />
                             </section>
 

--- a/src/pages/seeker/SavedJobsPage.tsx
+++ b/src/pages/seeker/SavedJobsPage.tsx
@@ -1,0 +1,150 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Header } from '../../components/Header';
+import { useAuth } from '../../hooks/useAuth';
+import { SavedJobsService } from '../../features/seeker/services/savedJobsService';
+import { ApplyModal } from '../../components/ApplyModal';
+import type { JobPosting } from '../../features/jobs/types';
+import { Loader2, Bookmark, MapPin, Briefcase, Trash2, Send } from 'lucide-react';
+
+export const SavedJobsPage: React.FC = () => {
+    const { user } = useAuth();
+    const navigate = useNavigate();
+    const [jobs, setJobs] = useState<JobPosting[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [applyingJob, setApplyingJob] = useState<JobPosting | null>(null);
+    const [actionLoadingId, setActionLoadingId] = useState<string | null>(null);
+    const [actionError, setActionError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!user) return;
+        const load = async () => {
+            try {
+                const saved = await SavedJobsService.getSavedBySeeker(user.uid);
+                setJobs(saved);
+            } catch (err) {
+                console.error('[SavedJobsPage] load error:', err);
+            } finally {
+                setLoading(false);
+            }
+        };
+        void load();
+    }, [user]);
+
+    const handleUnsave = async (jobId: string) => {
+        if (!user) return;
+        if (!jobId || actionLoadingId === jobId) return;
+        setActionLoadingId(jobId);
+        setActionError(null);
+        try {
+            await SavedJobsService.unsave(user.uid, jobId);
+            setJobs(prev => prev.filter(j => j.id !== jobId));
+        } catch (err) {
+            console.error('[SavedJobsPage] unsave failed:', err);
+            setActionError('Failed to remove saved job. Please try again.');
+        } finally {
+            setActionLoadingId(null);
+        }
+    };
+
+    return (
+        <div className="min-h-screen bg-sky-50 flex flex-col font-sans">
+            <Header />
+
+            <main className="flex-grow container mx-auto px-4 md:px-8 py-12 max-w-5xl">
+                <div className="mb-10 border-b border-slate-200 pb-8">
+                    <span className="text-xs font-semibold text-sky-600 uppercase tracking-widest mb-2 block">Seeker</span>
+                    <h1 className="text-3xl md:text-4xl font-bold text-slate-900 flex items-center gap-3">
+                        <Bookmark className="w-7 h-7 text-sky-700" />
+                        Saved Jobs
+                    </h1>
+                    <p className="text-sm text-slate-400 mt-1">Jobs you've bookmarked for later.</p>
+                </div>
+
+                {loading ? (
+                    <div className="flex flex-col items-center justify-center py-24 gap-3">
+                        <Loader2 className="w-8 h-8 animate-spin text-sky-600" />
+                        <p className="text-sm text-slate-400">Loading saved jobs...</p>
+                    </div>
+                ) : jobs.length === 0 ? (
+                    <div className="bg-white rounded-2xl border border-dashed border-slate-200 p-16 text-center">
+                        <Bookmark className="w-10 h-10 text-slate-300 mx-auto mb-4" />
+                        <p className="text-slate-500 mb-2 font-semibold">No saved jobs yet</p>
+                        <p className="text-sm text-slate-400 mb-6">Bookmark jobs from search results to come back to them.</p>
+                        <button
+                            onClick={() => { void navigate('/jobs'); }}
+                            className="inline-flex items-center gap-2 text-sm font-semibold bg-sky-700 hover:bg-sky-800 text-white px-6 py-2.5 rounded-xl transition-colors"
+                        >
+                            Browse Jobs
+                        </button>
+                    </div>
+                ) : (
+                    <div className="space-y-3">
+                        {actionError && (
+                            <div className="rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-600">
+                                {actionError}
+                            </div>
+                        )}
+                        {jobs.map(job => (
+                            <div
+                                key={job.id}
+                                className="bg-white rounded-2xl border border-slate-200 shadow-soft p-5 flex flex-col sm:flex-row sm:items-center justify-between gap-4"
+                            >
+                                <div
+                                    className="flex-1 min-w-0 cursor-pointer"
+                                    role="button"
+                                    tabIndex={0}
+                                    onClick={() => { void navigate(`/jobs/${job.id ?? ''}`); }}
+                                    onKeyDown={(e) => { if (e.key === 'Enter') { void navigate(`/jobs/${job.id ?? ''}`); } }}
+                                >
+                                    <p className="text-sm font-semibold text-slate-900 hover:text-sky-700 transition-colors">{job.title}</p>
+                                    <div className="flex flex-wrap items-center gap-3 mt-1 text-xs text-slate-400">
+                                        {job.location && (
+                                            <span className="flex items-center gap-1">
+                                                <MapPin className="w-3 h-3" /> {job.location}
+                                            </span>
+                                        )}
+                                        {job.type && (
+                                            <span className="flex items-center gap-1">
+                                                <Briefcase className="w-3 h-3" /> {job.type.replace(/_/g, ' ')}
+                                            </span>
+                                        )}
+                                    </div>
+                                </div>
+
+                                <div className="flex items-center gap-2 shrink-0">
+                                    <button
+                                        onClick={() => { setApplyingJob(job); }}
+                                        className="flex items-center gap-1.5 px-3 py-2 text-xs font-semibold bg-sky-700 hover:bg-sky-800 text-white rounded-xl transition-colors"
+                                    >
+                                        <Send className="w-3 h-3" /> Apply
+                                    </button>
+                                    <button
+                                        onClick={() => { void handleUnsave(job.id ?? ''); }}
+                                        title="Remove from saved"
+                                        disabled={actionLoadingId === job.id}
+                                        className="p-2 text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-xl border border-transparent hover:border-red-100 transition-colors"
+                                    >
+                                        {actionLoadingId === job.id ? (
+                                            <Loader2 className="w-4 h-4 animate-spin" />
+                                        ) : (
+                                            <Trash2 className="w-4 h-4" />
+                                        )}
+                                    </button>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </main>
+
+            {applyingJob && (
+                <ApplyModal
+                    job={applyingJob}
+                    isOpen={!!applyingJob}
+                    onClose={() => { setApplyingJob(null); }}
+                />
+            )}
+        </div>
+    );
+};

--- a/tests/features/jobs/jobService.test.ts
+++ b/tests/features/jobs/jobService.test.ts
@@ -1,140 +1,149 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { JobService } from '../../../src/features/jobs/services/jobService';
-import { getDocs, addDoc, getDoc } from 'firebase/firestore';
-import { CompanyService } from '../../../src/features/companies/services/companyService';
-import { callAIProxy } from '../../../src/lib/ai/proxy';
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { JobService } from "../../../src/features/jobs/services/jobService"
+import { getDocs, addDoc, getDoc } from "firebase/firestore"
+import { CompanyService } from "../../../src/features/companies/services/companyService"
+import { callAIProxy } from "../../../src/lib/ai/proxy"
 
 // Mock Firebase
-vi.mock('../../../src/lib/firebase', () => ({
-    db: {}
-}));
+vi.mock("../../../src/lib/firebase", () => ({
+  db: {},
+}))
 
-vi.mock('firebase/firestore', () => ({
-    collection: vi.fn(),
-    addDoc: vi.fn(),
-    serverTimestamp: vi.fn(() => 'mock-timestamp'),
-    doc: vi.fn(),
-    updateDoc: vi.fn(),
-    getDoc: vi.fn(),
-    query: vi.fn(),
-    where: vi.fn(),
-    orderBy: vi.fn(),
-    getDocs: vi.fn(),
-    limit: vi.fn(),
-    Timestamp: {
-        fromDate: vi.fn((date) => ({ toDate: () => date })),
-        now: vi.fn(() => ({ toDate: () => new Date() }))
-    }
-}));
+vi.mock("firebase/firestore", () => ({
+  collection: vi.fn(),
+  addDoc: vi.fn(),
+  serverTimestamp: vi.fn(() => "mock-timestamp"),
+  vector: vi.fn((values) => ({ __vector: values })),
+  doc: vi.fn(),
+  updateDoc: vi.fn(),
+  getDoc: vi.fn(),
+  query: vi.fn(),
+  where: vi.fn(),
+  orderBy: vi.fn(),
+  getDocs: vi.fn(),
+  limit: vi.fn(),
+  Timestamp: {
+    fromDate: vi.fn((date) => ({ toDate: () => date })),
+    now: vi.fn(() => ({ toDate: () => new Date() })),
+  },
+}))
 
-vi.mock('../../../src/features/companies/services/companyService', () => ({
-    CompanyService: {
-        getCompanyByEmployerId: vi.fn()
-    }
-}));
+vi.mock("../../../src/features/companies/services/companyService", () => ({
+  CompanyService: {
+    getCompanyByEmployerId: vi.fn(),
+  },
+}))
 
-vi.mock('../../../src/lib/ai/proxy', () => ({
-    callAIProxy: vi.fn()
-}));
+vi.mock("../../../src/lib/ai/proxy", () => ({
+  callAIProxy: vi.fn(),
+}))
 
-vi.mock('../../../src/lib/activity', () => ({
-    trackJobActivity: vi.fn()
-}));
+vi.mock("../../../src/lib/activity", () => ({
+  trackJobActivity: vi.fn(),
+}))
 
-describe('JobService', () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-    });
+describe("JobService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
 
-    describe('createJob', () => {
-        it('creates a job with generated embedding', async () => {
-            const mockInput = {
-                title: 'Software Engineer',
-                description: 'Build cool stuff',
-                skills: ['React', 'TypeScript'],
-                location: 'Remote',
-                type: 'full-time' as const,
-                work_mode: 'remote' as const,
-                employer_id: 'e1'
-            };
+  describe("createJob", () => {
+    it("creates a job with generated embedding", async () => {
+      const mockInput = {
+        title: "Software Engineer",
+        description: "Build cool stuff",
+        skills: ["React", "TypeScript"],
+        location: "Remote",
+        type: "full-time" as const,
+        work_mode: "remote" as const,
+        employer_id: "e1",
+      }
 
-            (CompanyService.getCompanyByEmployerId as any).mockResolvedValue({ id: 'c1' });
-            (callAIProxy as any).mockResolvedValue({ embedding: new Array(768).fill(0.1) });
-            (addDoc as any).mockResolvedValue({ id: 'job123' });
+      ;(CompanyService.getCompanyByEmployerId as any).mockResolvedValue({ id: "c1" })
+      ;(callAIProxy as any).mockResolvedValue({ embedding: new Array(768).fill(0.1) })
+      ;(addDoc as any).mockResolvedValue({ id: "job123" })
 
-            const jobId = await JobService.createJob(mockInput);
+      const jobId = await JobService.createJob(mockInput)
 
-            expect(jobId).toBe('job123');
-            expect(addDoc).toHaveBeenCalled();
-            expect(callAIProxy).toHaveBeenCalledWith('/api/ai/embedding', expect.anything());
-        });
+      expect(jobId).toBe("job123")
+      expect(addDoc).toHaveBeenCalled()
+      expect(callAIProxy).toHaveBeenCalledWith("/api/ai/embedding", expect.anything())
+    })
 
-        it('handles embedding service errors', async () => {
-            (callAIProxy as any).mockResolvedValue({ embedding: [0.1] }); // Wrong dimension
+    it("handles embedding service errors", async () => {
+      ;(callAIProxy as any).mockResolvedValue({ embedding: [0.1] }) // Wrong dimension
 
-            await expect(JobService.createJob({
-                title: 'T', description: 'D', skills: ['S'], location: 'L', type: 'full-time', work_mode: 'remote', employer_id: 'e1'
-            } as any)).rejects.toThrow(/invalid vector/);
-        });
-    });
+      await expect(
+        JobService.createJob({
+          title: "T",
+          description: "D",
+          skills: ["S"],
+          location: "L",
+          type: "full-time",
+          work_mode: "remote",
+          employer_id: "e1",
+        } as any),
+      ).rejects.toThrow(/invalid vector/)
+    })
+  })
 
-    describe('getJobs', () => {
-        it('fetches active jobs', async () => {
-            const mockSnap = {
-                docs: [
-                    { id: 'j1', data: () => ({ title: 'Job 1', status: 'active' }) },
-                    { id: 'j2', data: () => ({ title: 'Job 2', status: 'active' }) }
-                ]
-            };
-            (getDocs as any).mockResolvedValue(mockSnap);
+  describe("getJobs", () => {
+    it("fetches active jobs", async () => {
+      const mockSnap = {
+        docs: [
+          { id: "j1", data: () => ({ title: "Job 1", status: "active" }) },
+          { id: "j2", data: () => ({ title: "Job 2", status: "active" }) },
+        ],
+      }
+      ;(getDocs as any).mockResolvedValue(mockSnap)
 
-            const jobs = await JobService.getJobs();
-            expect(jobs).toHaveLength(2);
-            expect(jobs[0].title).toBe('Job 1');
-        });
-    });
+      const jobs = await JobService.getJobs()
+      expect(jobs).toHaveLength(2)
+      expect(jobs[0].title).toBe("Job 1")
+    })
+  })
 
-    describe('getJobById', () => {
-        it('returns job data if exists', async () => {
-            (getDoc as any).mockResolvedValue({
-                exists: () => true,
-                id: 'j1',
-                data: () => ({ title: 'Job 1' })
-            });
+  describe("getJobById", () => {
+    it("returns job data if exists", async () => {
+      ;(getDoc as any).mockResolvedValue({
+        exists: () => true,
+        id: "j1",
+        data: () => ({ title: "Job 1" }),
+      })
 
-            const job = await JobService.getJobById('j1');
-            expect(job?.title).toBe('Job 1');
-        });
+      const job = await JobService.getJobById("j1")
+      expect(job?.title).toBe("Job 1")
+    })
 
-        it('returns null if not found', async () => {
-            (getDoc as any).mockResolvedValue({ exists: () => false });
-            const job = await JobService.getJobById('missing');
-            expect(job).toBeNull();
-        });
-    });
+    it("returns null if not found", async () => {
+      ;(getDoc as any).mockResolvedValue({ exists: () => false })
+      const job = await JobService.getJobById("missing")
+      expect(job).toBeNull()
+    })
+  })
 
-    describe('getJobsByEmployerId', () => {
-        it('queries jobs by employer_id', async () => {
-            (getDocs as any).mockResolvedValue({ docs: [] });
-            await JobService.getJobsByEmployerId('e1');
-            expect(getDocs).toHaveBeenCalled();
-        });
-    });
+  describe("getJobsByEmployerId", () => {
+    it("queries jobs by employer_id", async () => {
+      ;(getDocs as any).mockResolvedValue({ docs: [] })
+      await JobService.getJobsByEmployerId("e1")
+      expect(getDocs).toHaveBeenCalled()
+    })
+  })
 
-    describe('getJobsByIds', () => {
-        it('fetches jobs in chunks of 10', async () => {
-            const ids = Array.from({ length: 15 }, (_, i) => `id${i}`);
-            (getDocs as any).mockResolvedValue({ docs: [] });
+  describe("getJobsByIds", () => {
+    it("fetches jobs in chunks of 10", async () => {
+      const ids = Array.from({ length: 15 }, (_, i) => `id${i}`)
+      ;(getDocs as any).mockResolvedValue({ docs: [] })
 
-            await JobService.getJobsByIds(ids);
+      await JobService.getJobsByIds(ids)
 
-            // Should call getDocs twice (one for 10, one for 5)
-            expect(getDocs).toHaveBeenCalledTimes(2);
-        });
+      // Should call getDocs twice (one for 10, one for 5)
+      expect(getDocs).toHaveBeenCalledTimes(2)
+    })
 
-        it('returns empty array for empty input', async () => {
-            const result = await JobService.getJobsByIds([]);
-            expect(result).toEqual([]);
-        });
-    });
-});
+    it("returns empty array for empty input", async () => {
+      const result = await JobService.getJobsByIds([])
+      expect(result).toEqual([])
+    })
+  })
+})

--- a/tests/seeker/shortlistService.test.ts
+++ b/tests/seeker/shortlistService.test.ts
@@ -50,6 +50,15 @@ vi.mock('firebase/firestore', () => {
             }
             toDate() { return new Date(this.seconds * 1000); }
         },
+        VectorValue: class {
+            private values: number[];
+            constructor(values: number[]) {
+                this.values = values;
+            }
+            toArray() {
+                return this.values;
+            }
+        },
         getFirestore: vi.fn(() => ({}))
     };
 });

--- a/tests/services.test.ts
+++ b/tests/services.test.ts
@@ -8,6 +8,7 @@ vi.mock('firebase/firestore', () => ({
     collection: vi.fn(),
     addDoc: vi.fn(),
     serverTimestamp: vi.fn(() => 'mock-timestamp'),
+    vector: vi.fn((value: number[]) => value),
     doc: vi.fn(),
     updateDoc: vi.fn(),
     getDoc: vi.fn(),
@@ -90,7 +91,7 @@ describe('Frontend Services Logic', () => {
             );
             expect(addDoc).toHaveBeenCalledWith(undefined, expect.objectContaining({
                 title: 'Software Engineer',
-                embedding: expect.any(Array)
+                embedding: expect.anything()
             }));
         });
 
@@ -117,7 +118,7 @@ describe('Frontend Services Logic', () => {
 
             expect(updateDoc).toHaveBeenCalledWith(undefined, expect.objectContaining({
                 title: 'Senior Software Engineer',
-                embedding: expect.any(Array)
+                embedding: expect.anything()
             }));
         });
     });


### PR DESCRIPTION
## Summary
- Add SavedJobsPage with unsave action, loading/error states
- Add BrownieLeaderboardPage for growth/points leaderboard
- Add AdminSettingsPage with platform config merge-on-load
- Add AdminUsersPage with paginated user loading and error handling
- Refactor AdminDashboard health status display logic
- Add savedJobsService for seeker saved-job management
- Fix ShortlistFeed: modal opens correctly based on applyingJob state
- Fix JobCard: apply button added, duplicate save prevention
- Fix JobsPage: duplicate save prevention, graceful error handling
- Update App.tsx routing for all new sprint-2 pages
- Update Firestore security rules for new collections (notifications, alerts, saved-jobs)
- Update tests: jobService, shortlistService, services

## Part of Sprint 2 — merge order
> **A → B → C → D** — this is the final PR, targets `sprint-2/pr-c-employer`
> After all 4 are reviewed and approved, merge A first, then B, C, D in order.
> Safety-net branch with all code: `sprint-2/staging`

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run test` — all unit tests pass
- [ ] SavedJobsPage: save and unsave a job end-to-end
- [ ] BrownieLeaderboard renders with real data
- [ ] AdminSettings loads and saves platform config
- [ ] AdminUsers paginates correctly
- [ ] All new routes in App.tsx resolve without 404

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)